### PR TITLE
bump v3.3.0: direct lazy-array streaming, cli improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,92 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+A volumetric 2-photon calcium imaging pipeline for Light Beads Microscopy (LBM) data, built as a **compatibility layer over upstream MouseLand/suite2p**. The package wraps suite2p's registration, detection, and extraction so an entire imaging *volume* (many z-planes) can be processed plane-by-plane with one set of parameters, plus diagnostics and plotting. I/O, lazy arrays, and metadata come from the sibling package `mbo_utilities`.
+
+## Commands
+
+```bash
+# dev install (uv recommended; pip works too)
+uv pip install -e ".[dev]"
+
+# run the test suite
+uv run pytest tests
+pytest tests/test_streaming.py                      # one file
+pytest tests/test_streaming.py::test_setitem_is_discarded   # one test
+
+# lint / format (ruff: line-length 88, numpy docstrings, select=ALL)
+ruff format .
+ruff check .
+
+# CLI
+lsp <input> <output> [options]      # run the pipeline
+lsp --list-ops                      # list every settable suite2p parameter
+lsp --version                       # fast; does not import suite2p
+lsp convert <dir> --to cellpose     # format conversion subcommand
+lsp detect <path>                   # format detection subcommand
+```
+
+Note: the GitHub Actions test step is **commented out** in `.github/workflows/test_python.yml`; CI currently only syncs deps and runs `ruff format`. Run tests locally. Many tests in `tests/test_streaming*.py` are `skipif` when suite2p/cv2 are absent.
+
+## Architecture
+
+### Call graph
+
+`pipeline()` is the single public entry point. It loads the input as a lazy array (via `mbo.imread`), detects 3D (single plane) vs 4D (volume), and delegates:
+
+```
+pipeline()                       run_lsp.py  — input detection, deprecation handling, db/settings flattening
+  ├─ run_volume()                run_lsp.py  — iterates planes; sequential OR ProcessPoolExecutor workers; aggregates volume_stats + volumetric plots
+  │    └─ run_plane()  (per plane)
+  └─ run_plane()                 run_lsp.py  — single plane: imwrite binary OR stream, then dispatch to one of:
+       ├─ run_plane_bin()        runs suite2p against data_raw.bin / data.bin on disk
+       └─ run_plane_stream()     streams frames straight from the lazy array (no binaries)
+            └─ _call_upstream_pipeline()      the bridge to suite2p.run_s2p.pipeline
+```
+
+The pipeline **always processes one plane and one channel at a time** — `default_ops()` forces `nplanes=1`, `nchannels=1`. "Volumetric" means looping `run_plane` over z, not handing suite2p a 4D array.
+
+### The upstream-compatibility seam (most important to understand)
+
+The fork uses a **flat `ops` dict** everywhere (`ops["meanImg"]`, `ops["yrange"]`, `ops["fs"]`, ...). Upstream suite2p moved to **nested `db` + `settings` dicts** and a `pipeline()` that returns a 12-tuple instead of a merged ops. Two modules absorb that mismatch — touch them whenever a suite2p upgrade breaks things:
+
+- **`_call_upstream_pipeline()`** (`run_lsp.py`): splits flat ops into `(db, settings)`, overlays them onto a fresh `default_settings()` (so new upstream keys fall back to upstream defaults rather than crashing), resolves the torch device, calls upstream `pipeline()`, then folds the returned `reg_outputs` / `detect_outputs` dicts back into the flat ops dict.
+- **`db_settings.py`**: the bidirectional flat↔nested translation (`db_settings_to_ops`, `ops_to_db_settings`, `merge_db_settings_into_ops`). Section membership tables (`_SETTINGS_SECTIONS`, etc.) mirror upstream's `default_settings()`/`default_db()` shapes and must stay in sync with them. Fork-only keys (`dff_*`, `keep_raw`, registration outputs, mbo metadata) live in `ops.npy` only and do not round-trip.
+
+`compute_enhanced_mean_image()` is similarly a shim for an upstream rename (`highpass_mean_image`). Expect more such shims when bumping suite2p.
+
+### Ops resolution
+
+`default_ops.py` defines the parameter baseline: `s2p_ops()` returns suite2p's own defaults flattened through `db_settings_to_ops`; `default_ops()` overlays a small `_LBM_DETECTION_DEFAULTS` set on top. A caller-supplied `ops=` is respected as-is (not overlaid). `pipeline()`/`run_plane()` accept **either** flat `ops=` **or** nested `db=`/`settings=`; when both are given, the nested pair is flattened first and explicit `ops` keys win. `reconcile_detection_keys()` keeps the fork's `anatomical_only`/`sparse_mode` spellings and suite2p's `algorithm` spelling consistent and valid.
+
+### Streaming mode (`stream=True`)
+
+`streaming.py` / `streaming_array.py` let suite2p run without ever writing the full `data_raw.bin` / `data.bin`:
+
+- **`StreamingBinaryFile`** is a duck-typed stand-in for suite2p's `BinaryFile`. As `f_raw` it returns int16 frames sliced from the lazy array; as `f_reg` (`registered=True`) it **discards writes** and reconstitutes registered frames on read by replaying the shifts suite2p saved to `reg_outputs.npy` (bidiphase + rigid roll + nonrigid `transform_data`). Reconstituted frames are byte-identical to `data.bin` (verified in `tests/test_streaming.py`) because the same raw source, shifts, block layout, and int16 cast are reused. The only persisted binary artifact is the tiny `reg_outputs.npy`.
+- Streaming is **functional-channel-only**; a chan2/structural file or a `.bin` input falls back to the binary path. `two_step_registration` is auto-disabled.
+- **`RegisteredStreamArray`** (`streaming_array.py`) is the mbo_utilities side: registered via the `mbo_utilities.lazy_arrays` entry point in `pyproject.toml`, it lets `mbo <plane_dir>` / `imread(<plane_dir>)` open a binary-less plane dir (ops.npy + reg_outputs.npy, no .bin) as a lazy registered array. It is deliberately isolated from `streaming.py` so a load failure can never break mbo_utilities.
+
+### Lazy imports
+
+`__init__.py` uses PEP 562 `__getattr__` to map every public name to its submodule, imported on first access. Importing the package does **not** pull in suite2p / cv2 / matplotlib, so `lsp --version` / `--help` stay fast. The CLI (`cli.py`) mirrors this: `build_parser(include_ops=False)` skips enumerating suite2p ops (which would import suite2p) for the `--help` / no-arg / `--version` / `--list-ops` fast paths. When adding a public function, register it in both `_LAZY_ATTRS` and `__all__`.
+
+### Parallelism & device
+
+- `run_volume(workers=...)`: `1` = sequential; `None`/`<=0` = auto `min(num_planes, cpu_count//2, 8)`; `>1` = that many `ProcessPoolExecutor` workers. Parallel mode requires a **path-based** input (workers re-`imread` the source; lazy arrays may not survive spawn) and writes to disjoint per-plane subdirs. Worker logs are funneled back through a multiprocessing log queue. Cellpose on GPU can OOM with multiple workers.
+- `MBO_GPU` env var → `CUDA_VISIBLE_DEVICES` (resolved before torch init via `_resolve_gpu_env()`); `threads_per_worker` caps BLAS/OMP/numba/torch threads.
+
+### Naming & metadata conventions
+
+- Plane output dirs are named `zplaneNN[_tpSTART-STOP][_suffix]` via `generate_plane_dirname()` using mbo_utilities dimension tags.
+- **Frame-count aliases**: mbo_utilities and this package both write a set of synonym keys (`nframes`, `num_frames`, `num_timepoints`, `n_frames`, `T`, `nt`, `timepoints`) that must stay in lockstep — use `_set_frame_count_aliases()` to fan a count out to all of them.
+- The canonical user-facing selection params are `timepoints` (1-based) and `planes` (1-based). `frames` / `frame_indices` (0-based) and `roi` / `num_frames` are **deprecated aliases** that emit `DeprecationWarning` (see `_resolve_timepoints`).
+
+## Conventions & gotchas
+
+- `torch` and `torchvision` are pinned to the **cu126** index in `pyproject.toml` (`[tool.uv.sources]`). They are direct deps — removing them reverts torch to the CPU build.
+- This is an upstream **fork-tracking** project: when suite2p is bumped, the breakage is almost always in `_call_upstream_pipeline` / `db_settings.py` (new required `settings` keys, renamed functions, changed return shapes). The overlay-onto-`default_settings()` pattern is intentional insurance against new keys.
+- suite2p / cellpose loggers have no handlers by default; `_attach_external_loggers()` wires them to stdout so registration/detection progress is visible.

--- a/lbm_suite2p_python/__init__.py
+++ b/lbm_suite2p_python/__init__.py
@@ -18,9 +18,12 @@ _LAZY_ATTRS = {
     "pipeline": "run_lsp",
     "run_volume": "run_lsp",
     "run_plane": "run_lsp",
+    "run_plane_stream": "run_lsp",
     "add_processing_step": "run_lsp",
     "generate_plane_dirname": "run_lsp",
     "compute_enhanced_mean_image": "run_lsp",
+    # streaming
+    "StreamingBinaryFile": "streaming",
     # cellpose
     "train_cellpose": "cellpose",
     "annotate": "cellpose",
@@ -105,6 +108,8 @@ __all__ = [
     "pipeline",
     "run_volume",
     "run_plane",
+    "run_plane_stream",
+    "StreamingBinaryFile",
     "default_ops",
     "add_processing_step",
     "generate_plane_dirname",

--- a/lbm_suite2p_python/__init__.py
+++ b/lbm_suite2p_python/__init__.py
@@ -1,95 +1,104 @@
+import importlib
 from importlib.metadata import version, PackageNotFoundError
-
-from lbm_suite2p_python.default_ops import default_ops
-from lbm_suite2p_python.run_lsp import (
-    pipeline,
-    run_volume,
-    run_plane,
-    add_processing_step,
-    generate_plane_dirname,
-    compute_enhanced_mean_image
-)
-
-from lbm_suite2p_python.cellpose import (
-    train_cellpose,
-    annotate,
-    open_in_gui,
-    prepare_training_data,
-    masks_to_stat,
-    stat_to_masks,
-)
-from lbm_suite2p_python.conversion import (
-    export_for_gui,
-    import_from_gui,
-    get_results,
-    ensure_cellpose_format,
-    detect_format,
-)
-
-# Plotting exports
-from lbm_suite2p_python.zplane import (
-    plot_traces,
-    animate_traces,
-    plot_zplane_figures,
-    plot_plane_quality_metrics,
-    plot_plane_diagnostics,
-    plot_trace_analysis,
-    plot_multiplane_masks,
-    plot_mask_comparison,
-    plot_regional_zoom,
-    plot_filtered_cells,
-    plot_diameter_histogram,
-    plot_projection,
-    plot_accepted_rejected_overlay,
-    plot_volume_accepted_rejected_overlay,
-)
-
-from lbm_suite2p_python.volume import (
-    plot_volume_diagnostics,
-    plot_orthoslices,
-    plot_3d_roi_map,
-    plot_3d_rastermap_clusters,
-    plot_volume_trace_figures,
-    plot_volume_signal,
-    plot_volume_neuron_counts,
-    consolidate_volume,
-)
-
-from lbm_suite2p_python.grid_search import (
-    grid_search,
-    collect_grid_results,
-    save_grid_results,
-    plot_grid_metrics,
-    get_best_parameters,
-    print_best_parameters,
-    plot_grid_distributions,
-    plot_grid_masks,
-)
-
-from lbm_suite2p_python.postprocessing import (
-    load_ops,
-    load_planar_results,
-    dff_rolling_percentile,
-    dff_median_filter,
-    zscore_trace,
-    baseline_percentile_dff,
-    dff_shot_noise,
-    compute_roi_stats,
-)
-
-# Re-export key modules for easier access
-from lbm_suite2p_python import (
-    cellpose,
-    conversion,
-    utils,
-    postprocessing,
-)
 
 try:
     __version__ = version("lbm_suite2p_python")
 except PackageNotFoundError:
     # fallback for editable installs
     __version__ = "0.0.0"
+
+# Lazy attribute -> submodule map (PEP 562). Importing the package no longer
+# pulls in the whole pipeline stack (suite2p, cv2, matplotlib, ...); each name
+# is imported from its submodule on first access. Keeps `lsp --help` / version
+# fast and importable without the heavy scientific deps installed.
+_LAZY_ATTRS = {
+    # default_ops
+    "default_ops": "default_ops",
+    # run_lsp
+    "pipeline": "run_lsp",
+    "run_volume": "run_lsp",
+    "run_plane": "run_lsp",
+    "add_processing_step": "run_lsp",
+    "generate_plane_dirname": "run_lsp",
+    "compute_enhanced_mean_image": "run_lsp",
+    # cellpose
+    "train_cellpose": "cellpose",
+    "annotate": "cellpose",
+    "open_in_gui": "cellpose",
+    "prepare_training_data": "cellpose",
+    "masks_to_stat": "cellpose",
+    "stat_to_masks": "cellpose",
+    # conversion
+    "export_for_gui": "conversion",
+    "import_from_gui": "conversion",
+    "get_results": "conversion",
+    "ensure_cellpose_format": "conversion",
+    "detect_format": "conversion",
+    # zplane plotting
+    "plot_traces": "zplane",
+    "animate_traces": "zplane",
+    "plot_zplane_figures": "zplane",
+    "plot_plane_quality_metrics": "zplane",
+    "plot_plane_diagnostics": "zplane",
+    "plot_trace_analysis": "zplane",
+    "plot_multiplane_masks": "zplane",
+    "plot_mask_comparison": "zplane",
+    "plot_regional_zoom": "zplane",
+    "plot_filtered_cells": "zplane",
+    "plot_diameter_histogram": "zplane",
+    "plot_projection": "zplane",
+    "plot_accepted_rejected_overlay": "zplane",
+    "plot_volume_accepted_rejected_overlay": "zplane",
+    # volume plotting
+    "plot_volume_diagnostics": "volume",
+    "plot_orthoslices": "volume",
+    "plot_3d_roi_map": "volume",
+    "plot_3d_rastermap_clusters": "volume",
+    "plot_volume_trace_figures": "volume",
+    "plot_volume_signal": "volume",
+    "plot_volume_neuron_counts": "volume",
+    "consolidate_volume": "volume",
+    # grid search
+    "grid_search": "grid_search",
+    "collect_grid_results": "grid_search",
+    "save_grid_results": "grid_search",
+    "plot_grid_metrics": "grid_search",
+    "get_best_parameters": "grid_search",
+    "print_best_parameters": "grid_search",
+    "plot_grid_distributions": "grid_search",
+    "plot_grid_masks": "grid_search",
+    # postprocessing
+    "load_ops": "postprocessing",
+    "load_planar_results": "postprocessing",
+    "dff_rolling_percentile": "postprocessing",
+    "dff_median_filter": "postprocessing",
+    "zscore_trace": "postprocessing",
+    "baseline_percentile_dff": "postprocessing",
+    "dff_shot_noise": "postprocessing",
+    "compute_roi_stats": "postprocessing",
+}
+
+# Re-exported submodules for easier access (lsp.cellpose, lsp.utils, ...).
+_LAZY_SUBMODULES = frozenset({"cellpose", "conversion", "utils", "postprocessing"})
+
+
+def __getattr__(name):
+    if name in _LAZY_SUBMODULES:
+        mod = importlib.import_module(f"{__name__}.{name}")
+        globals()[name] = mod
+        return mod
+    module_name = _LAZY_ATTRS.get(name)
+    if module_name is not None:
+        mod = importlib.import_module(f"{__name__}.{module_name}")
+        attr = getattr(mod, name)
+        globals()[name] = attr
+        return attr
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(__all__)
+
 
 __all__ = [
     # Core API
@@ -99,7 +108,7 @@ __all__ = [
     "default_ops",
     "add_processing_step",
     "generate_plane_dirname",
-    "compute_enhanced_mean_image"
+    "compute_enhanced_mean_image",
 
     # Cellpose / HITL Workflow
     "train_cellpose",

--- a/lbm_suite2p_python/cli.py
+++ b/lbm_suite2p_python/cli.py
@@ -91,10 +91,13 @@ def _get_ops_help() -> dict[str, str]:
     }
 
 
-def build_parser() -> argparse.ArgumentParser:
-    """build the argument parser with all pipeline and ops parameters."""
-    from lbm_suite2p_python.default_ops import s2p_ops
+def build_parser(include_ops: bool = True) -> argparse.ArgumentParser:
+    """build the argument parser with all pipeline and ops parameters.
 
+    When ``include_ops`` is False the per-parameter suite2p flags are not
+    enumerated (enumerating them imports suite2p). Used for the fast
+    ``--help`` / no-arg paths; ``--list-ops`` shows the full list instead.
+    """
     parser = argparse.ArgumentParser(
         prog="lsp",
         description="LBM Suite2p Pipeline - process calcium imaging data",
@@ -252,18 +255,24 @@ Examples:
     )
 
     # reader options (forwarded to mbo_utilities.imread)
-    reader = parser.add_argument_group("reader options (raw scanimage data)")
+    reader = parser.add_argument_group(
+        "reader options",
+        description="Forwarded to mbo_utilities.imread(). --reader-kwargs passes "
+                    "any imread argument as JSON and works for every lazy array "
+                    "type (tiff, zarr, hdf5, bin, ...); the named flags below are "
+                    "conveniences for raw ScanImage TIFFs."
+    )
     reader.add_argument(
         "--fix-phase", action=argparse.BooleanOptionalAction, default=None,
-        help="bidirectional phase correction (reader default: on)"
+        help="bidirectional phase correction (ScanImage TIFF; reader default: on)"
     )
     reader.add_argument(
         "--use-fft", action=argparse.BooleanOptionalAction, default=None,
-        help="FFT-based subpixel phase correction"
+        help="FFT-based subpixel phase correction (ScanImage TIFF)"
     )
     reader.add_argument(
         "--phasecorr-method", choices=["mean", "median", "max"], default=None,
-        help="phase-correction reduction method (default: mean)"
+        help="phase-correction reduction method (ScanImage TIFF; default: mean)"
     )
     reader.add_argument(
         "--channel", type=int, default=None,
@@ -271,14 +280,19 @@ Examples:
     )
     reader.add_argument(
         "--reader-kwargs", type=str, default=None, metavar="JSON",
-        help='extra imread kwargs as JSON, e.g. \'{"roi": 2}\''
+        help='any mbo_utilities.imread() kwargs as JSON, e.g. \'{"roi": 2}\''
     )
 
-    # writer options (forwarded to the binary/zarr writer)
-    writer = parser.add_argument_group("writer options")
+    # writer options (forwarded to mbo_utilities.imwrite)
+    writer = parser.add_argument_group(
+        "writer options",
+        description="Forwarded to mbo_utilities.imwrite() (a different argument "
+                    "set than the reader). --writer-kwargs passes any imwrite "
+                    "argument as JSON."
+    )
     writer.add_argument(
         "--writer-kwargs", type=str, default=None, metavar="JSON",
-        help='extra writer kwargs as JSON, e.g. \'{"target_chunk_mb": 200}\''
+        help='any mbo_utilities.imwrite() kwargs as JSON, e.g. \'{"target_chunk_mb": 200}\''
     )
 
     # rastermap options
@@ -305,12 +319,20 @@ Examples:
     )
 
     # dynamically add all ops parameters
-    ops_defaults = s2p_ops()
-    ops_help = _get_ops_help()
     ops_group = parser.add_argument_group(
         "suite2p parameters",
-        description="all suite2p ops can be set via --param-name value"
+        description="all suite2p ops can be set via --param-name value; "
+                    "run 'lsp --list-ops' to list them"
     )
+
+    # enumerating every suite2p op requires importing suite2p; skip it for the
+    # fast --help / no-arg paths (see build_parser docstring)
+    if not include_ops:
+        return parser
+
+    from lbm_suite2p_python.default_ops import s2p_ops
+    ops_defaults = s2p_ops()
+    ops_help = _get_ops_help()
 
     # skip params already handled above
     skip_params = {"frames_include"}
@@ -571,7 +593,6 @@ def _run_detect(args):
 
 def main():
     """main CLI entrypoint."""
-    import lbm_suite2p_python as lsp
     from lbm_suite2p_python import __version__
 
     # check for subcommands before parsing
@@ -589,17 +610,22 @@ def main():
         if subcommand == "detect":
             return _run_detect(sys.argv[2:])
 
-    parser = build_parser()
-    args = parser.parse_args()
+    argv = sys.argv[1:]
 
-    # handle info commands
-    if args.version:
+    # fast info paths: don't import suite2p / the pipeline stack just to print
+    if "--version" in argv:
         print(f"lbm_suite2p_python v{__version__}")
         return 0
 
-    if args.list_ops:
+    if "--list-ops" in argv:
         list_ops()
         return 0
+
+    # --help and the no-arg usage dump only need the static parser; building the
+    # full parser enumerates every suite2p op, which imports suite2p.
+    include_ops = bool(argv) and "-h" not in argv and "--help" not in argv
+    parser = build_parser(include_ops=include_ops)
+    args = parser.parse_args()
 
     # validate required args
     if not args.input:
@@ -654,6 +680,7 @@ def main():
     print(f"Output: {output_path}")
 
     # build ops (optionally starting from a user-supplied ops file)
+    import lbm_suite2p_python as lsp
     base_ops = lsp.default_ops(ops=base_extra_ops) if base_extra_ops else lsp.default_ops()
     ops = build_ops(args, base_ops)
 

--- a/lbm_suite2p_python/cli.py
+++ b/lbm_suite2p_python/cli.py
@@ -184,6 +184,12 @@ Examples:
         help="force re-detection even if results exist"
     )
     pipeline.add_argument(
+        "--stream", action="store_true",
+        help="stream frames from the lazy array through suite2p instead of "
+             "writing data_raw.bin / data.bin (only reg_outputs.npy persists; "
+             "registered frames reconstituted on the fly). Functional channel only."
+    )
+    pipeline.add_argument(
         "--save-json", action="store_true",
         help="save ops as JSON (in addition to .npy)"
     )
@@ -679,9 +685,14 @@ def main():
     print(f"Input:  {input_path}")
     print(f"Output: {output_path}")
 
-    # build ops (optionally starting from a user-supplied ops file)
+    # build ops (optionally starting from a user-supplied ops file).
+    # import default_ops directly: build_parser(include_ops=True) already did
+    # `from ...default_ops import s2p_ops`, which binds the default_ops submodule
+    # onto the package, shadowing the lazily-exported function — so
+    # `lsp.default_ops` would resolve to the module here, not the callable.
     import lbm_suite2p_python as lsp
-    base_ops = lsp.default_ops(ops=base_extra_ops) if base_extra_ops else lsp.default_ops()
+    from lbm_suite2p_python.default_ops import default_ops
+    base_ops = default_ops(ops=base_extra_ops) if base_extra_ops else default_ops()
     ops = build_ops(args, base_ops)
 
     # build cell filters
@@ -721,6 +732,7 @@ def main():
             keep_raw=args.keep_raw,
             force_reg=args.force_reg or args.overwrite,
             force_detect=args.force_detect or args.overwrite,
+            stream=args.stream,
             dff_window_size=args.dff_window_size,
             dff_percentile=args.dff_percentile,
             dff_smooth_window=args.dff_smooth_window,

--- a/lbm_suite2p_python/run_lsp.py
+++ b/lbm_suite2p_python/run_lsp.py
@@ -830,6 +830,7 @@ def pipeline(
     force_reg: bool = False,
     force_detect: bool = False,
     replot: bool = True,
+    stream: bool = False,
     timepoints: list | int | None = None,
     num_timepoints: int = None,
     num_zplanes: int = None,
@@ -898,6 +899,11 @@ def pipeline(
         Regenerate per-plane figures. Set False to skip per-plane figure
         regeneration (e.g. the volumetric aggregate over already-plotted
         planes); suite2p and the volumetric plots are unaffected.
+    stream : bool, default False
+        Stream frames directly from the lazy array through suite2p instead of
+        writing data_raw.bin / data.bin. Only reg_outputs.npy (the registration
+        shifts) is persisted; registered frames are reconstituted on the fly.
+        Functional channel only. See run_plane for details.
     timepoints : list[int] or int, optional
         Explicit 1-based timepoints to process. Supports stride
         (e.g. ``list(range(1, 1575, 2))`` for every other timepoint).
@@ -1082,6 +1088,7 @@ def pipeline(
             force_reg=force_reg,
             force_detect=force_detect,
             replot=replot,
+            stream=stream,
             timepoints=timepoints,
             dff_window_size=dff_window_size,
             dff_percentile=dff_percentile,
@@ -1122,6 +1129,7 @@ def pipeline(
             force_reg=force_reg,
             force_detect=force_detect,
             replot=replot,
+            stream=stream,
             timepoints=timepoints,
             dff_window_size=dff_window_size,
             dff_percentile=dff_percentile,
@@ -1294,6 +1302,7 @@ def run_volume(
     force_reg: bool = False,
     force_detect: bool = False,
     replot: bool = True,
+    stream: bool = False,
     timepoints: list | int | None = None,
     num_timepoints: int = None,
     num_zplanes: int = None,
@@ -1343,6 +1352,10 @@ def run_volume(
     replot : bool, default True
         Regenerate per-plane figures (passed to run_plane). Set False to skip
         per-plane figure regeneration during a volumetric aggregate.
+    stream : bool, default False
+        Stream frames from the lazy array through suite2p per plane instead of
+        writing data_raw.bin / data.bin (see run_plane). Applies to both the
+        sequential and parallel-worker paths.
     frame_indices : list, default None
         List of frame indices to process.
     dff_window_size, dff_percentile, dff_smooth_window : optional
@@ -1492,6 +1505,7 @@ def run_volume(
         force_reg=force_reg,
         force_detect=force_detect,
         replot=replot,
+        stream=stream,
         timepoints=timepoints,
         dff_window_size=dff_window_size,
         dff_percentile=dff_percentile,
@@ -2319,6 +2333,169 @@ def run_plane_bin(ops) -> bool:
     return True
 
 
+def _resolve_stream_device(ops):
+    """Resolve a torch device for on-the-fly shift reconstitution.
+
+    Mirrors `_call_upstream_pipeline`'s probe so the reconstitution runs on the
+    same device registration used (cross-device float rounding in the nonrigid
+    grid_sample could otherwise flip a few int16 pixels). Returns None when
+    torch is unavailable.
+    """
+    try:
+        import torch
+    except ImportError:
+        return None
+    name = ops.get("torch_device") or "cuda"
+    try:
+        dev = torch.device(name)
+        if dev.type == "cuda":
+            torch.zeros(1, device=dev)  # probe that cuda is usable
+        return dev
+    except Exception:
+        return torch.device("cpu")
+
+
+def _default_block_size(ops):
+    """Nonrigid block size that registration will use (ops override or upstream default)."""
+    bs = ops.get("block_size")
+    if not bs:
+        try:
+            from suite2p import default_settings
+            bs = default_settings()["registration"]["block_size"]
+        except Exception:
+            bs = [128, 128]
+    return (int(bs[0]), int(bs[1]))
+
+
+def run_plane_stream(ops, arr, plane_index, channel_index=0, frame_indices=None):
+    """Run Suite2p on a streamed mbo lazy-array plane — no data_raw.bin/data.bin.
+
+    Computes registration shifts from the streamed raw frames (suite2p saves
+    them to reg_outputs.npy) and reconstitutes registered frames on the fly for
+    detection/extraction via `StreamingBinaryFile`. The only persisted binary
+    artifact is reg_outputs.npy; the registered movie never lands on disk or in
+    a full-size RAM buffer.
+
+    Parameters
+    ----------
+    ops : dict or str or Path
+        Suite2p ops. Must carry Ly, Lx, a frame count, and save_path/ops_path.
+    arr : mbo lazy array
+        5D TCZYX source the plane is streamed from.
+    plane_index : int
+        0-based Z index to process.
+    channel_index : int, default 0
+        0-based functional channel.
+    frame_indices : list[int], optional
+        0-based source timepoints to process (truncation / strided selection).
+
+    Returns
+    -------
+    bool
+        True on success.
+    """
+    from lbm_suite2p_python.streaming import StreamingBinaryFile
+
+    ops = load_ops(ops)
+    save_path = Path(ops["save_path"])
+    ops["ops_path"] = str(save_path / "ops.npy")
+
+    Ly, Lx = int(ops["Ly"]), int(ops["Lx"])
+    n_align = ops.get("nframes_chan1") or ops.get("nframes") or ops.get("n_frames")
+    if n_align is None:
+        raise KeyError("Missing nframes_chan1 / nframes / n_frames in ops")
+    n_align = int(n_align)
+    if n_align <= 0:
+        raise ValueError("Non-positive frame count for streaming run.")
+
+    run_registration = bool(ops.get("do_registration", True))
+    run_detection = bool(ops.get("roidetect", True))
+
+    # two-step registration re-reads f_reg mid-registration (to build a second
+    # reference) before the shifts are persisted — incompatible with
+    # reconstitute-on-read. Force it off so reconstitution stays correct.
+    if run_registration and ops.get("two_step_registration"):
+        logger.warning(
+            "two_step_registration is not supported in streaming mode; disabling it."
+        )
+        ops["two_step_registration"] = 0
+
+    # streaming is single (functional) channel only.
+    ops["functional_chan"] = 1
+    ops["align_by_chan"] = 1
+    ops["nchannels"] = 1
+    _set_frame_count_aliases(ops, n_align)
+    ops["nframes_chan1"] = n_align
+
+    if "diameter" in ops:
+        ops["diameter_user"] = ops["diameter"]
+
+    # clear stale detection/registration intermediates (mirrors run_plane_bin).
+    if run_registration:
+        for key in [
+            "spatscale_pix", "Vcorr", "Vmax", "Vmap", "Vsplit", "ihop",
+            "badframes", "xoff", "yoff", "corrXY",
+            "xoff1", "yoff1", "corrXY1",
+        ]:
+            ops.pop(key, None)
+    elif run_detection:
+        for key in ["spatscale_pix", "Vmax", "Vmap", "Vsplit", "ihop"]:
+            ops.pop(key, None)
+
+    # resolve one device for both the pipeline and the reconstitution so
+    # registered frames are bit-identical to a data.bin written on that device.
+    device = _resolve_stream_device(ops)
+    if device is not None:
+        ops["torch_device"] = device.type
+
+    raw_stream = StreamingBinaryFile(
+        arr, plane_index, channel_index=channel_index, n_frames=n_align,
+        frame_indices=frame_indices, registered=False, device=device,
+    )
+
+    if run_registration:
+        f_raw = raw_stream
+        f_reg = StreamingBinaryFile(
+            arr, plane_index, channel_index=channel_index, n_frames=n_align,
+            frame_indices=frame_indices, registered=True, save_path=save_path,
+            block_size=_default_block_size(ops), nonrigid=bool(ops.get("nonrigid", True)),
+            device=device,
+        )
+    else:
+        # already-registered upstream: detection/extraction read raw directly.
+        f_raw = None
+        f_reg = raw_stream
+        # registration normally produces these; synthesize so detection runs.
+        if "meanImg" not in ops:
+            ops["meanImg"] = raw_stream.sampled_mean().astype(np.float32)
+        if "meanImgE" not in ops and "meanImg" in ops:
+            ops["meanImgE"] = compute_enhanced_mean_image(
+                ops["meanImg"].astype(np.float32), ops
+            )
+
+    # very short recordings crash suite2p's bin_movie (bin_size > nframes);
+    # pre-seed summary images from raw and clamp tau so bin_size <= nframes.
+    tau_fs = np.round(ops.get("tau", 0.7) * ops.get("fs", 30))
+    if n_align < max(tau_fs, 2):
+        allf = np.asarray(raw_stream[:n_align]).astype(np.float32)
+        ops["meanImg"] = allf.mean(axis=0)
+        ops["max_proj"] = allf.max(axis=0)
+        ops["tau"] = 0
+
+    ops = _call_upstream_pipeline(
+        ops, f_reg, f_raw, None, None,
+        run_registration=run_registration, stat=None,
+    )
+
+    if "meanImgE" not in ops and "meanImg" in ops:
+        ops["meanImgE"] = compute_enhanced_mean_image(
+            ops["meanImg"].astype(np.float32), ops
+        )
+
+    save_ops_db_settings(ops["ops_path"], ops)
+    return True
+
+
 def _cleanup_bin_files(plane_dir, keep_raw, keep_reg):
     """delete bin files if user doesn't want them, swallowing OS errors."""
     if not keep_raw:
@@ -2345,6 +2522,7 @@ def run_plane(
     force_reg: bool = False,
     force_detect: bool = False,
     replot: bool = True,
+    stream: bool = False,
     timepoints: list | int | None = None,
     num_timepoints: int = None,
     frame_indices: list | None = None,
@@ -2394,6 +2572,13 @@ def run_plane(
     replot : bool, default True
         Generate per-plane figures. Set False to skip figure generation
         (keeps ROI stats; only the figures are skipped).
+    stream : bool, default False
+        If True, stream frames directly from the lazy array through suite2p
+        instead of writing data_raw.bin / data.bin. Registration shifts are
+        saved to reg_outputs.npy and registered frames are reconstituted on the
+        fly for detection/extraction; no full-size binary touches disk or RAM.
+        Functional channel only — a chan2/structural file falls back to the
+        binary path. two_step_registration is auto-disabled.
     dff_window_size : int, optional
         Frames for rolling percentile baseline. Default: auto-calculated (~10*tau*fs).
     dff_percentile : int, default 20
@@ -2512,6 +2697,22 @@ def run_plane(
     skip_imwrite = False
     is_binary_input = input_path.suffix == ".bin"
     binary_with_ops = is_binary_input and (input_path.parent / "ops.npy").exists()
+
+    # streaming requires a frame source to stream from (a lazy array / readable
+    # input), single functional channel, and does not apply to a .bin input
+    # (already a suite2p binary). Fall back to the binary path otherwise.
+    if stream and chan2_file is not None:
+        logger.warning(
+            "stream=True does not support a chan2/structural file yet; "
+            "using the binary path for this run."
+        )
+        stream = False
+    if stream and is_binary_input:
+        logger.warning(
+            "stream=True ignored: input is already a suite2p .bin; using the "
+            "binary path."
+        )
+        stream = False
 
     # load ops defaults and user settings first (needed for plane number).
     # accepts EITHER ops=... (legacy flat dict) OR db=... / settings=... (new
@@ -2761,7 +2962,13 @@ def run_plane(
             expected_ly=exp_ly,
             expected_lx=exp_lx,
         )
-        if should_write:
+        if stream:
+            # streaming: never write a binary, but keep the array + metadata so
+            # the fs/dz/dim propagation below still runs (dims stamped later).
+            file = input_arr if input_arr is not None else imread(input_path, **reader_kwargs)
+            metadata = dict(file.metadata) if hasattr(file, "metadata") else get_metadata(input_path)
+            should_write = False
+        elif should_write:
             if input_arr is not None:
                 file = input_arr
             else:
@@ -2863,10 +3070,38 @@ def run_plane(
     ops["source_dirname"] = plane_dir.name
     ops["source_input"] = str(input_path.name)
 
+    # streaming: imwrite is skipped, so stamp the dims it would otherwise have
+    # written into ops.npy (suite2p reads Ly/Lx/nframes from ops).
+    if stream and file is not None:
+        _s5 = file._shape5d() if hasattr(file, "_shape5d") else (
+            file.shape[0], 1, 1, file.shape[-2], file.shape[-1]
+        )
+        ops["Ly"], ops["Lx"] = int(_s5[3]), int(_s5[4])
+        if frame_indices is not None:
+            _n_stream = len(frame_indices)
+        else:
+            _n_stream = int(
+                writer_kwargs.get("num_timepoints")
+                or writer_kwargs.get("num_frames")
+                or _s5[0]
+            )
+            _n_stream = min(_n_stream, int(_s5[0]))
+        _set_frame_count_aliases(ops, _n_stream)
+        ops["nframes_chan1"] = _n_stream
+        # record the reader settings the raw was read with so a later viewer
+        # (mbo studio's RegisteredStreamArray) can reproduce the exact frames
+        # the shifts were computed on.
+        ops["reader_kwargs"] = dict(reader_kwargs)
+        # record the canonical raw source imread can reconstruct the FULL
+        # assembled volume from (the dir/series), not just data_path's first
+        # file — so the viewer reads the same frames the shifts were computed on.
+        _raw_src = getattr(file, "source_path", None)
+        ops["raw_source"] = str(_raw_src) if _raw_src else str(input_path)
+
     # Write binary
     if progress_callback:
         progress_callback(step="writing_binary", message="Writing binary...")
-    if not skip_imwrite and file is not None:
+    if not skip_imwrite and file is not None and not stream:
         md_combined = {**metadata, **ops}
         print(f"Writing binary to {plane_dir}...")
         bin_start = time.time()
@@ -3042,7 +3277,14 @@ def run_plane(
             progress_callback(step="suite2p", message="Running suite2p...")
         try:
             s2p_start = time.time()
-            processed = run_plane_bin(ops)
+            if stream:
+                plane_index0 = (plane - 1) if _get_num_planes(file) > 1 else 0
+                processed = run_plane_stream(
+                    ops, file, plane_index0,
+                    channel_index=0, frame_indices=frame_indices,
+                )
+            else:
+                processed = run_plane_bin(ops)
 
             if processed:
                 updated_ops = load_ops(ops_file)

--- a/lbm_suite2p_python/streaming.py
+++ b/lbm_suite2p_python/streaming.py
@@ -1,0 +1,304 @@
+"""Stream mbo lazy arrays through suite2p without writing data_raw.bin / data.bin.
+
+suite2p's ``pipeline()`` consumes ``f_reg`` / ``f_raw`` purely by duck typing —
+its docstring allows ``numpy.ndarray or BinaryFile``. Registration reads
+``f_raw`` and writes registered frames into ``f_reg``; detection and extraction
+only ever *read* ``f_reg``. ``StreamingBinaryFile`` is a drop-in for that
+surface, backed by a single (channel, plane) of a 5D TCZYX mbo lazy array:
+
+- As ``f_raw`` (read-only source): ``__getitem__`` returns int16 frames
+  ``arr[t, c, z]`` — byte-identical to what mbo's ``imwrite`` would put in
+  ``data_raw.bin``.
+- As ``f_reg`` with ``registered=True``: writes are discarded (registered
+  frames are never materialized); reads reconstitute registered frames on the
+  fly from the shifts suite2p saves to ``<save_path>/reg_outputs.npy``, by
+  replaying suite2p's own ``bidiphase.shift`` + ``register.shift_frames``
+  (rigid ``torch.roll`` + nonrigid ``transform_data``). Only the tiny
+  ``reg_outputs.npy`` ever touches disk.
+
+Reconstituted frames are identical to ``data.bin`` because the raw source, the
+stored shifts, the recomputed ``make_blocks(Ly, Lx, block_size)`` layout, and
+the int16 cast are all the same ones registration used.
+
+Single (functional) channel only; ``arr`` must support 5D ``[t, c, z, :, :]``
+indexing (every mbo ``LazyArray`` does).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+
+class StreamingBinaryFile:
+    """suite2p ``BinaryFile``-compatible view of one plane of an mbo lazy array.
+
+    Parameters
+    ----------
+    arr : mbo lazy array
+        5D TCZYX source. Indexed as ``arr[t, channel_index, plane_index, :, :]``.
+    plane_index : int
+        0-based Z index to expose.
+    channel_index : int, default 0
+        0-based channel index (functional channel).
+    n_frames : int, optional
+        Number of timepoints to expose. Defaults to the source T (or the length
+        of ``frame_indices`` when given).
+    frame_indices : list[int], optional
+        0-based source timepoints this stream maps onto (for truncation or
+        strided ``timepoints=`` selections). Stream index ``i`` reads source
+        timepoint ``frame_indices[i]``. None means identity.
+    registered : bool, default False
+        If True, reads reconstitute registered frames from ``reg_outputs.npy``.
+        If False, reads return raw frames.
+    save_path : str or Path, optional
+        Plane directory holding ``reg_outputs.npy`` (required when registered).
+    block_size : tuple[int, int], default (128, 128)
+        Nonrigid block size — must match the value registration used so the
+        recomputed block layout is identical.
+    nonrigid : bool, default True
+        Whether nonrigid shifts were computed. When False, only rigid shifts
+        are applied even if ``reg_outputs.npy`` carries nonrigid arrays.
+    device : torch.device, optional
+        Device for the reconstitution (rigid roll + nonrigid grid_sample).
+        Use the same device registration ran on so frames match bit-for-bit.
+    """
+
+    def __init__(
+        self,
+        arr,
+        plane_index,
+        *,
+        channel_index=0,
+        n_frames=None,
+        frame_indices=None,
+        registered=False,
+        save_path=None,
+        block_size=(128, 128),
+        nonrigid=True,
+        device=None,
+    ):
+        self._arr = arr
+        self._z = int(plane_index)
+        self._c = int(channel_index)
+
+        if hasattr(arr, "_shape5d"):
+            s5 = arr._shape5d()
+        else:  # natural-rank fallback (T, Y, X)
+            s5 = (arr.shape[0], 1, 1, arr.shape[-2], arr.shape[-1])
+        self.Ly, self.Lx = int(s5[3]), int(s5[4])
+
+        # 0-based source timepoints this stream exposes (identity if None).
+        self._tmap = (
+            np.asarray(frame_indices, dtype=np.int64)
+            if frame_indices is not None
+            else None
+        )
+        if self._tmap is not None:
+            self.n_frames = int(len(self._tmap))
+        elif n_frames is not None:
+            self.n_frames = int(n_frames)
+        else:
+            self.n_frames = int(s5[0])
+
+        self.dtype = np.int16
+        self.write = False
+
+        self._registered = bool(registered)
+        self._save_path = Path(save_path) if save_path is not None else None
+        self._block_size = (int(block_size[0]), int(block_size[1]))
+        self._nonrigid = bool(nonrigid)
+        self._device = device
+        self._shifts = None  # lazily loaded reg_outputs (yoff/xoff/.../blocks)
+
+    @classmethod
+    def from_run(
+        cls,
+        arr,
+        plane_dir,
+        *,
+        plane_index=0,
+        channel_index=0,
+        n_frames=None,
+        frame_indices=None,
+        device=None,
+    ):
+        """Registered view of ``arr`` reconstructed from a completed run's shifts.
+
+        Reads ``plane_dir/reg_outputs.npy`` (the shifts) and ``plane_dir/ops.npy``
+        (the ``block_size`` / ``nonrigid`` the run used) and returns a
+        registered ``StreamingBinaryFile`` — indexing it yields the registered
+        frames on the fly, applying the saved shifts to ``arr``. Works whether
+        or not the run used streaming; only the saved shifts matter.
+
+        Parameters
+        ----------
+        arr : mbo lazy array
+            The raw 5D TCZYX source the shifts were computed from.
+        plane_dir : str or Path
+            Plane output directory containing reg_outputs.npy and ops.npy.
+        plane_index, channel_index : int
+            Which plane/channel of ``arr`` the shifts correspond to.
+        n_frames, frame_indices : optional
+            Frame selection — must match the frames the run registered (the
+            shift arrays have one entry per registered frame).
+        device : torch.device, optional
+            Device for the shift application.
+
+        Examples
+        --------
+        >>> import mbo_utilities as mbo
+        >>> from lbm_suite2p_python import StreamingBinaryFile
+        >>> raw = mbo.imread("D:/data/raw")               # 5D TCZYX
+        >>> reg = StreamingBinaryFile.from_run(raw, "D:/out/zplane01_tp00001-01000")
+        >>> frames = reg[:1000]    # registered int16 frames, reconstituted lazily
+        """
+        plane_dir = Path(plane_dir)
+        ops = np.load(plane_dir / "ops.npy", allow_pickle=True).item()
+        block_size = ops.get("block_size") or (128, 128)
+        # the shift arrays have exactly one entry per registered frame; default
+        # the exposed length to that so a truncated run (e.g. num_timepoints)
+        # lines up without the caller having to remember the count. A strided
+        # `timepoints=` run needs the same `frame_indices` passed explicitly.
+        if n_frames is None and frame_indices is None:
+            reg_outputs = np.load(plane_dir / "reg_outputs.npy", allow_pickle=True).item()
+            n_frames = int(len(np.asarray(reg_outputs["yoff"])))
+        return cls(
+            arr,
+            plane_index,
+            channel_index=channel_index,
+            n_frames=n_frames,
+            frame_indices=frame_indices,
+            registered=True,
+            save_path=plane_dir,
+            block_size=block_size,
+            nonrigid=bool(ops.get("nonrigid", True)),
+            device=device,
+        )
+
+    # ---- BinaryFile surface ------------------------------------------------
+    @property
+    def shape(self):
+        return (self.n_frames, self.Ly, self.Lx)
+
+    @property
+    def size(self):
+        return int(self.n_frames) * int(self.Ly) * int(self.Lx)
+
+    def __len__(self):
+        return self.n_frames
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    def close(self):
+        pass
+
+    def __setitem__(self, key, value):
+        # Registered frames are virtual (reconstituted on read) and the raw
+        # source is read-only — registration's writes have nothing to persist.
+        return
+
+    def __getitem__(self, key):
+        idx, squeeze = self._time_indices(key)
+        raw = np.asarray(self._read_raw(idx)) if idx.size else np.empty(
+            (0, self.Ly, self.Lx), dtype=np.int16
+        )
+        # guard empty reads (empty slice, or a window function indexing past the
+        # end): never hand 0 frames to shift_frames (torch.stack would raise).
+        if self._registered and len(raw):
+            out = self._apply_shifts(raw, idx)
+        else:
+            out = raw.astype(np.int16, copy=False)
+        return out[0] if (squeeze and len(out)) else out
+
+    @property
+    def data(self):
+        return self[:]
+
+    def sampled_mean(self):
+        """Mean image from up to 1000 evenly spaced frames (mirrors BinaryFile)."""
+        nsamps = min(self.n_frames, 1000)
+        inds = np.linspace(0, self.n_frames, 1 + nsamps).astype(np.int64)[:-1]
+        return self[inds].astype(np.float32).mean(axis=0)
+
+    # ---- internals ---------------------------------------------------------
+    def _time_indices(self, key):
+        """Resolve an axis-0 key into (stream_indices, squeeze_scalar)."""
+        if isinstance(key, slice):
+            return np.arange(*key.indices(self.n_frames), dtype=np.int64), False
+        if isinstance(key, (int, np.integer)):
+            i = int(key)
+            if i < 0:
+                i += self.n_frames
+            return np.array([i], dtype=np.int64), True
+        return np.asarray(key, dtype=np.int64), False
+
+    def _read_raw(self, idx):
+        """Read source frames for stream indices ``idx`` -> (N, Ly, Lx) int16."""
+        src = self._tmap[idx] if self._tmap is not None else idx
+        # contiguous run -> single slice read (fast path); else gather frame-wise
+        # (robust to backends that don't support fancy time indexing).
+        if np.array_equal(src, np.arange(src[0], src[0] + len(src))):
+            sl = slice(int(src[0]), int(src[0]) + len(src))
+            out = np.asarray(self._arr[sl, self._c, self._z, :, :])
+        else:
+            out = np.stack(
+                [np.asarray(self._arr[int(i), self._c, self._z, :, :]) for i in src]
+            )
+        return np.ascontiguousarray(out)
+
+    def _load_shifts(self):
+        if self._shifts is not None:
+            return self._shifts
+        from suite2p.registration import nonrigid as s2p_nonrigid
+
+        reg = np.load(self._save_path / "reg_outputs.npy", allow_pickle=True).item()
+        yoff1 = reg.get("yoff1") if self._nonrigid else None
+        has_nr = yoff1 is not None
+        self._shifts = {
+            "yoff": np.asarray(reg["yoff"]),
+            "xoff": np.asarray(reg["xoff"]),
+            "yoff1": np.asarray(reg["yoff1"]) if has_nr else None,
+            "xoff1": np.asarray(reg["xoff1"]) if has_nr else None,
+            "bidiphase": int(reg.get("bidiphase", 0) or 0),
+            "blocks": (
+                s2p_nonrigid.make_blocks(self.Ly, self.Lx, self._block_size)
+                if has_nr
+                else None
+            ),
+        }
+        return self._shifts
+
+    def _apply_shifts(self, raw, idx):
+        """Reconstitute registered frames by replaying suite2p's shift application."""
+        import torch
+        from suite2p.registration import bidiphase as bidi, register
+
+        sh = self._load_shifts()
+        fr = torch.from_numpy(np.ascontiguousarray(raw))
+        if self._device is not None:
+            fr = fr.to(self._device)
+        if sh["bidiphase"] != 0:
+            fr = bidi.shift(fr, sh["bidiphase"])
+
+        yoff = sh["yoff"][idx].astype(int)
+        xoff = sh["xoff"][idx].astype(int)
+        if sh["yoff1"] is not None:
+            yoff1, xoff1 = sh["yoff1"][idx], sh["xoff1"][idx]
+        else:
+            yoff1 = xoff1 = None
+
+        dev = self._device if self._device is not None else torch.device("cpu")
+        out = np.asarray(
+            register.shift_frames(fr, yoff, xoff, yoff1, xoff1, sh["blocks"], device=dev)
+        )
+        # suite2p's nonrigid transform_data squeezes the batch axis for a single
+        # frame; keep the (N, Ly, Lx) contract so __getitem__'s squeeze is correct.
+        if out.ndim == 2:
+            out = out[np.newaxis]
+        return out

--- a/lbm_suite2p_python/streaming_array.py
+++ b/lbm_suite2p_python/streaming_array.py
@@ -1,0 +1,213 @@
+"""mbo studio integration: open a binary-less suite2p plane directory as a lazy
+registered array (raw frames + saved shifts, reconstituted on the fly).
+
+Registered with mbo_utilities via the ``mbo_utilities.lazy_arrays`` entry point
+(see pyproject), so ``mbo <plane_dir>`` / ``imread(<plane_dir>)`` returns a
+``RegisteredStreamArray`` when the directory has:
+
+- ``ops.npy`` + ``reg_outputs.npy`` (the registration shifts), and
+- **no** ``data.bin`` / ``data_raw.bin`` (a streamed run, or a binary run whose
+  ``.bin`` files were cleaned up by the default ``keep_reg``/``keep_raw=False``),
+  and
+- a locatable raw source (``ops['data_path']``).
+
+It carries ``PRIORITY`` above ``Suite2pArray`` (100) so it claims those dirs
+first; when a real binary is present, ``can_open`` returns False and
+``Suite2pArray`` reads it directly. The class is intentionally isolated from
+``streaming.py`` (the pipeline-critical module): if the mbo base classes ever
+move, only the entry-point load fails — mbo skips it and the pipeline is
+unaffected.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from mbo_utilities.lazy_array import LazyArray
+from mbo_utilities.arrays._base import ReductionMixin, _normalize_key
+
+from lbm_suite2p_python.streaming import StreamingBinaryFile
+
+
+def _recorded_raw_exists(ops: dict) -> bool:
+    """True if the exact raw source recorded by the run is on disk.
+
+    Used by ``can_open`` — deliberately strict (exact path, no parent guessing)
+    so a stale/moved source declines cleanly instead of matching an unrelated
+    directory. ``raw_source`` (the canonical full source the run read) is
+    preferred; ``data_path`` (the first raw file) is the legacy fallback.
+    """
+    for key in ("raw_source", "data_path"):
+        v = ops.get(key)
+        if v and Path(v).exists():
+            return True
+    return False
+
+
+def _open_raw(ops: dict, n_needed: int):
+    """imread the raw source as the FULL assembled volume.
+
+    ``data_path`` records only the first raw file; ``imread`` of that single
+    file can return fewer/un-assembled frames than the run processed. So try, in
+    order: the recorded ``raw_source``, the containing directory of
+    ``data_path`` (which reconstructs the assembled series), then ``data_path``
+    itself — and prefer the first whose timepoint count covers the registered
+    frames. Returns the opened array, or None when nothing is usable.
+    """
+    from mbo_utilities import imread
+
+    cands = []
+    rs = ops.get("raw_source")
+    if rs:
+        cands.append(Path(rs))
+    dp = ops.get("data_path")
+    if dp:
+        p = Path(dp)
+        if p.suffix and p.parent != p:
+            cands.append(p.parent)  # series dir -> assembled volume
+        cands.append(p)
+
+    seen, fallback = set(), None
+    for c in cands:
+        s = str(c)
+        if s in seen or not c.exists():
+            continue
+        seen.add(s)
+        try:
+            arr = imread(c, **(ops.get("reader_kwargs") or {}))
+        except Exception:
+            continue
+        try:
+            nt = int(arr._shape5d()[0])
+        except Exception:
+            nt = None
+        if nt is None or nt >= n_needed:
+            return arr
+        fallback = fallback or arr  # short, but better than nothing
+    return fallback
+
+
+def _has_binary(plane_dir: Path) -> bool:
+    return (plane_dir / "data.bin").exists() or (plane_dir / "data_raw.bin").exists()
+
+
+def _pick_device():
+    """cuda if usable, else cpu, else None (torch absent)."""
+    try:
+        import torch
+    except Exception:
+        return None
+    try:
+        if torch.cuda.is_available():
+            torch.zeros(1, device="cuda")
+            return torch.device("cuda")
+    except Exception:
+        pass
+    return torch.device("cpu")
+
+
+class RegisteredStreamArray(ReductionMixin, LazyArray):
+    """Lazy registered view of one suite2p plane, rebuilt from raw + shifts.
+
+    Presents a 5D ``(T, 1, 1, Ly, Lx)`` array whose frames are the registered
+    frames suite2p would have written to ``data.bin`` — reconstituted on demand
+    from the raw source and ``reg_outputs.npy`` via ``StreamingBinaryFile``.
+    """
+
+    PRIORITY = 150  # above Suite2pArray (100): claim binary-less reg dirs first
+
+    @classmethod
+    def can_open(cls, path) -> bool:
+        try:
+            p = Path(path)
+            if p.name == "ops.npy":
+                p = p.parent
+            if not p.is_dir():
+                return False
+            if not ((p / "ops.npy").exists() and (p / "reg_outputs.npy").exists()):
+                return False
+            if _has_binary(p):
+                return False  # real binary present -> Suite2pArray reads it directly
+            ops = np.load(p / "ops.npy", allow_pickle=True).item()
+            return _recorded_raw_exists(ops)
+        except Exception:
+            return False
+
+    def __init__(self, path, device=None):
+        from mbo_utilities import imread
+        from lbm_suite2p_python.utils import _get_num_planes
+
+        p = Path(path)
+        if p.name == "ops.npy":
+            p = p.parent
+        self._plane_dir = p
+        self._ops = np.load(p / "ops.npy", allow_pickle=True).item()
+
+        reg_outputs = np.load(p / "reg_outputs.npy", allow_pickle=True).item()
+        self._nt = int(len(np.asarray(reg_outputs["yoff"])))
+
+        # re-read raw (with the run's reader_kwargs) as the full assembled volume.
+        self._raw = _open_raw(self._ops, self._nt)
+        if self._raw is None:
+            raise FileNotFoundError(
+                f"RegisteredStreamArray: raw source not found for {p}. "
+                f"raw_source={self._ops.get('raw_source')!r}, "
+                f"data_path={self._ops.get('data_path')!r} are not on disk. "
+                "Re-point the raw data or open the plane with its data.bin."
+            )
+
+        plane = int(self._ops.get("plane", 1) or 1)
+        self._plane_index = (plane - 1) if _get_num_planes(self._raw) > 1 else 0
+        self._device = device if device is not None else _pick_device()
+
+        self._stream = StreamingBinaryFile.from_run(
+            self._raw, p, plane_index=self._plane_index,
+            n_frames=self._nt, device=self._device,
+        )
+        self._Ly, self._Lx = self._stream.Ly, self._stream.Lx
+        self.filenames = [p / "ops.npy"]
+
+    # ---- LazyArray contract ------------------------------------------------
+    def _shape5d(self):
+        return (self._nt, 1, 1, self._Ly, self._Lx)
+
+    @property
+    def dtype(self):
+        return np.dtype(np.int16)
+
+    @property
+    def metadata(self) -> dict:
+        return dict(self._ops)
+
+    @property
+    def source_path(self):
+        return self._plane_dir
+
+    def __len__(self):
+        return self._nt
+
+    def __array__(self, dtype=None, copy=None):
+        """Representative registered frame (for vmin/vmax preview)."""
+        frame = np.asarray(self._stream[0])
+        return frame.astype(dtype) if dtype is not None else frame
+
+    def __getitem__(self, key):
+        key = _normalize_key(key, 5)
+        key = key + (slice(None),) * (5 - len(key))
+        t_key, c_key, z_key, y_key, x_key = key
+
+        frames = np.asarray(self._stream[t_key])  # (N,Ly,Lx) or (Ly,Lx) for int t
+        t_is_int = isinstance(t_key, (int, np.integer))
+        if frames.ndim == 2:
+            frames = frames[np.newaxis]           # normalize to (N,Ly,Lx)
+
+        # promote to canonical (T, C, Z, Y, X) with singleton C/Z, then index
+        # C/Z/Y/X (integer keys squeeze, slices keep) and finally drop T if it
+        # was an integer index — matching numpy basic-indexing semantics.
+        out = frames[:, np.newaxis, np.newaxis, :, :]
+        out = out[:, c_key, z_key, y_key, x_key]
+        if t_is_int and len(out):
+            out = out[0]
+        return out

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,13 @@ dependencies = [
 lsp = "lbm_suite2p_python.__main__:main"
 cellpose-gui = "lbm_suite2p_python.gui:main"
 
+# Open a binary-less suite2p plane dir (ops.npy + reg_outputs.npy, no .bin) as a
+# lazy registered array in mbo / mbo studio — raw frames + saved shifts applied
+# on the fly. mbo auto-discovers this via its lazy-array plugin group; a load
+# failure is skipped, so this can never break mbo_utilities.
+[project.entry-points."mbo_utilities.lazy_arrays"]
+lbm_registered_stream = "lbm_suite2p_python.streaming_array:RegisteredStreamArray"
+
 [project.optional-dependencies]
 rastermap = [
 	"rastermap",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lbm_suite2p_python"
-version = "3.2.2"
+version = "3.2.3"
 description = "Calcium Imaging Pipeline built with Suite2p, Cellpose and Rastermap"
 readme = "README.md"
 license = "BSD-3-Clause"
@@ -18,7 +18,7 @@ classifiers=[
 ]
 
 dependencies = [
-	"mbo_utilities>=3.2.7",
+	"mbo_utilities>=3.3.0",
 	"suite2p>=1.0.0.1",
 	"setuptools<81",
 	"torch",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lbm_suite2p_python"
-version = "3.2.3"
+version = "3.3.0"
 description = "Calcium Imaging Pipeline built with Suite2p, Cellpose and Rastermap"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,0 +1,244 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["numpy", "pytest", "lbm_suite2p_python"]
+# ///
+"""Tests for streaming mbo lazy arrays through suite2p (no data_raw.bin/data.bin).
+
+Two layers:
+- The raw-streaming surface (StreamingBinaryFile read path) is validated against
+  a synthetic 5D array with no suite2p dependency — runs anywhere.
+- The registered reconstitution is validated to be *byte-identical* to what
+  suite2p's registration writes to data.bin. That needs suite2p installed and is
+  skipped otherwise.
+"""
+
+import numpy as np
+import pytest
+
+from lbm_suite2p_python.streaming import StreamingBinaryFile
+
+try:
+    import suite2p  # noqa: F401
+
+    _HAS_SUITE2P = True
+except Exception:
+    _HAS_SUITE2P = False
+
+
+class _Arr5D:
+    """Minimal stand-in for an mbo lazy array (5D TCZYX, numpy-backed)."""
+
+    def __init__(self, data5d):
+        self._d = np.asarray(data5d)
+
+    def _shape5d(self):
+        return self._d.shape
+
+    @property
+    def shape(self):
+        return self._d.shape
+
+    def __getitem__(self, key):
+        return self._d[key]
+
+
+def _make_arr(T=20, C=1, Z=3, Ly=8, Lx=6, seed=0):
+    rng = np.random.default_rng(seed)
+    data = rng.integers(-100, 4000, size=(T, C, Z, Ly, Lx)).astype(np.int16)
+    return _Arr5D(data), data
+
+
+def test_raw_stream_shape_and_dtype():
+    arr, data = _make_arr()
+    f = StreamingBinaryFile(arr, plane_index=2, channel_index=0, n_frames=20)
+    assert f.shape == (20, 8, 6)
+    assert f.Ly == 8 and f.Lx == 6 and f.n_frames == 20
+    assert f[:].dtype == np.int16
+
+
+def test_raw_stream_slice_matches_source():
+    arr, data = _make_arr()
+    z, c = 1, 0
+    f = StreamingBinaryFile(arr, plane_index=z, channel_index=c, n_frames=data.shape[0])
+    assert np.array_equal(f[3:9], data[3:9, c, z])
+    assert np.array_equal(f[:], data[:, c, z])
+
+
+def test_raw_stream_fancy_and_scalar_index():
+    arr, data = _make_arr()
+    z, c = 2, 0
+    f = StreamingBinaryFile(arr, plane_index=z, channel_index=c, n_frames=data.shape[0])
+    # non-contiguous fancy index (registration samples a reference this way)
+    idx = np.array([0, 5, 5, 11, 2])
+    assert np.array_equal(f[idx], data[idx, c, z])
+    # scalar index squeezes the time axis, like BinaryFile
+    assert np.array_equal(f[7], data[7, c, z])
+    assert f[7].shape == (8, 6)
+
+
+def test_raw_stream_frame_indices_tmap():
+    arr, data = _make_arr(T=20)
+    z, c = 0, 0
+    sel = [1, 3, 5, 7, 9]  # 0-based source timepoints (strided selection)
+    f = StreamingBinaryFile(
+        arr, plane_index=z, channel_index=c, frame_indices=sel
+    )
+    assert f.n_frames == len(sel)
+    assert np.array_equal(f[:], data[sel, c, z])
+    assert np.array_equal(f[1:3], data[[3, 5], c, z])
+
+
+def test_setitem_is_discarded():
+    arr, data = _make_arr()
+    f = StreamingBinaryFile(arr, plane_index=0, channel_index=0, n_frames=data.shape[0])
+    before = f[:].copy()
+    f[0:3] = np.zeros((3, 8, 6), np.int16)  # registration "writes" — must no-op
+    assert np.array_equal(f[:], before)
+
+
+def test_sampled_mean_runs():
+    arr, data = _make_arr()
+    f = StreamingBinaryFile(arr, plane_index=0, channel_index=0, n_frames=data.shape[0])
+    m = f.sampled_mean()
+    assert m.shape == (8, 6) and m.dtype == np.float32
+
+
+def test_registered_empty_and_oob_reads_dont_crash(tmp_path):
+    """A window function / stats sampler can index an empty slice or past the
+    end; those must return empty, never hand 0 frames to shift_frames (the GUI
+    crash was torch.stack on an empty list)."""
+    arr, data = _make_arr(T=10, Ly=8, Lx=6)
+    N = data.shape[0]
+    np.save(tmp_path / "reg_outputs.npy", {
+        "yoff": np.zeros(N, np.int64), "xoff": np.zeros(N, np.int64),
+        "yoff1": None, "xoff1": None, "bidiphase": 0,
+    })
+    f = StreamingBinaryFile(
+        arr, plane_index=0, channel_index=0, n_frames=N, registered=True,
+        save_path=tmp_path, nonrigid=False,  # rigid-only: no suite2p needed here
+    )
+    assert f[N:N + 3].shape == (0, 8, 6)   # slice entirely past the end
+    assert f[5:5].shape == (0, 8, 6)       # empty slice
+    assert f[N].shape == (0, 8, 6)         # out-of-range scalar (guarded, no crash)
+
+
+def _synthetic_registered_movie(N=300, Ly=96, Lx=96, max_shift=3, seed=1):
+    """A base image with blobs, translated by known integer shifts per frame.
+
+    Frames must exceed the nonrigid block size or suite2p's own registration
+    degenerates to a single block (real LBM planes are far larger); the test
+    shrinks block_size so 96x96 still tiles into multiple blocks.
+    """
+    rng = np.random.default_rng(seed)
+    yy, xx = np.mgrid[0:Ly, 0:Lx]
+    base = np.zeros((Ly, Lx), np.float32)
+    for cy, cx, amp in [(0.3, 0.35, 1500), (0.6, 0.6, 2200), (0.45, 0.75, 1800)]:
+        base += amp * np.exp(
+            -(((yy - cy * Ly) ** 2 + (xx - cx * Lx) ** 2) / (2 * 6.0 ** 2))
+        )
+    base += 200
+    shifts = rng.integers(-max_shift, max_shift + 1, size=(N, 2))
+    frames = np.empty((N, Ly, Lx), np.int16)
+    for i, (dy, dx) in enumerate(shifts):
+        frames[i] = np.roll(base, (dy, dx), axis=(0, 1)).astype(np.int16)
+    return frames
+
+
+@pytest.mark.skipif(not _HAS_SUITE2P, reason="suite2p (and cv2) required")
+def test_registered_reconstitution_is_byte_identical(tmp_path):
+    """StreamingBinaryFile(registered=True) must reproduce, frame-for-frame, what
+    suite2p's registration writes to data.bin — same raw source, same shifts,
+    same block layout, same int16 cast."""
+    import torch
+    from suite2p import default_settings
+    from suite2p.registration.register import registration_wrapper
+
+    device = torch.device("cpu")  # deterministic; no GPU needed for the test
+    settings = default_settings()
+    reg = settings["registration"]
+    reg["block_size"] = [32, 32]  # tile the small test frames into many blocks
+
+    raw = _synthetic_registered_movie()
+    N, Ly, Lx = raw.shape
+    arr = _Arr5D(raw[:, None, None, :, :])  # (N, 1, 1, Ly, Lx)
+
+    # f_raw is the raw stream (exactly what run_plane_stream feeds registration);
+    # f_reg is an in-RAM ndarray that captures the registered frames suite2p
+    # writes — the data.bin ground truth.
+    f_raw_stream = StreamingBinaryFile(arr, plane_index=0, channel_index=0, n_frames=N)
+    f_reg = np.zeros((N, Ly, Lx), np.int16)
+    reg_outputs = registration_wrapper(
+        f_reg, f_raw=f_raw_stream, save_path=str(tmp_path), settings=reg, device=device
+    )
+    # mimic pipeline_s2p saving the shifts right after registration.
+    np.save(tmp_path / "reg_outputs.npy", reg_outputs)
+
+    stream = StreamingBinaryFile(
+        arr, plane_index=0, channel_index=0, n_frames=N, registered=True,
+        save_path=tmp_path, block_size=reg["block_size"],
+        nonrigid=reg["nonrigid"], device=device,
+    )
+
+    recon = stream[:]
+    assert recon.shape == f_reg.shape
+    assert recon.dtype == np.int16
+    assert np.array_equal(recon, f_reg), (
+        f"reconstituted frames differ from registration output: "
+        f"{int((recon != f_reg).sum())} / {recon.size} pixels"
+    )
+
+    # batched reads must match the full read (detection/extraction read in chunks)
+    assert np.array_equal(stream[100:175], f_reg[100:175])
+    # single-frame read (GUI scrub) must keep the (Ly, Lx) frame shape
+    assert stream[123].shape == (Ly, Lx)
+    assert np.array_equal(stream[123], f_reg[123])
+
+
+@pytest.mark.skipif(not _HAS_SUITE2P, reason="suite2p (and cv2) required")
+def test_run_plane_stream_writes_no_binaries(tmp_path):
+    """End-to-end: run_plane_stream runs registration + detection + extraction
+    straight off the lazy array, writing the usual .npy outputs and reg_outputs
+    but never data_raw.bin / data.bin."""
+    from lbm_suite2p_python.default_ops import default_ops
+    from lbm_suite2p_python.run_lsp import run_plane_stream
+
+    rng = np.random.default_rng(0)
+    N, Ly, Lx = 300, 96, 96
+    yy, xx = np.mgrid[0:Ly, 0:Lx]
+    base = np.zeros((Ly, Lx), np.float32)
+    for cy, cx, amp in [(28, 30, 1800), (60, 58, 2400), (45, 72, 2000)]:
+        base += amp * np.exp(-(((yy - cy) ** 2 + (xx - cx) ** 2) / (2 * 5.0 ** 2)))
+    base += 300
+    sh = rng.integers(-2, 3, size=(N, 2))
+    mov = np.empty((N, Ly, Lx), np.int16)
+    for i, (dy, dx) in enumerate(sh):
+        mov[i] = (np.roll(base, (dy, dx), axis=(0, 1))
+                  + rng.normal(0, 15, (Ly, Lx))).astype(np.int16)
+    arr = _Arr5D(mov[:, None, None, :, :])
+
+    ops = default_ops()
+    ops.update({
+        "Ly": Ly, "Lx": Lx, "nframes": N, "nframes_chan1": N,
+        "save_path": str(tmp_path), "ops_path": str(tmp_path / "ops.npy"),
+        "do_registration": 1, "roidetect": 1, "fs": 10.0, "tau": 1.0,
+        "block_size": [32, 32], "torch_device": "cpu",
+    })
+
+    assert run_plane_stream(ops, arr, 0) is True
+    for name in ("reg_outputs.npy", "ops.npy", "stat.npy", "F.npy", "iscell.npy"):
+        assert (tmp_path / name).exists(), f"missing {name}"
+    assert not (tmp_path / "data_raw.bin").exists()
+    assert not (tmp_path / "data.bin").exists()
+
+    # the saved shifts can be re-applied to the raw array via from_run, reading
+    # block_size / nonrigid back from the run's ops.npy.
+    import torch
+
+    reg = StreamingBinaryFile.from_run(
+        arr, tmp_path, plane_index=0, device=torch.device("cpu")
+    )
+    assert reg._registered and reg.n_frames == N
+    out = reg[:]
+    assert out.shape == (N, Ly, Lx) and out.dtype == np.int16
+    # shifts were applied: registered frames differ from the raw source
+    assert not np.array_equal(out, mov)

--- a/tests/test_streaming_array.py
+++ b/tests/test_streaming_array.py
@@ -1,0 +1,163 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["numpy", "pytest", "tifffile", "mbo_utilities", "lbm_suite2p_python"]
+# ///
+"""mbo studio integration: RegisteredStreamArray opens a binary-less suite2p
+plane dir (ops.npy + reg_outputs.npy, no .bin) as a lazy registered array.
+
+Layered like test_streaming.py: can_open / dispatch routing need no suite2p; the
+end-to-end frame check (register synthetic data, open via mbo.imread, verify the
+registered frames) is gated on suite2p.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from lbm_suite2p_python.streaming import StreamingBinaryFile
+from lbm_suite2p_python.streaming_array import RegisteredStreamArray
+
+try:
+    import suite2p  # noqa: F401
+
+    _HAS_SUITE2P = True
+except Exception:
+    _HAS_SUITE2P = False
+
+
+def _make_plane_dir(tmp_path, *, with_binary=False, with_reg=True, data_path=None):
+    """Fabricate a suite2p-shaped plane dir with controllable file presence."""
+    d = tmp_path / "plane"
+    d.mkdir(parents=True, exist_ok=True)
+    ops = {"Ly": 8, "Lx": 6, "nframes": 5, "plane": 1}
+    if data_path is not None:
+        ops["data_path"] = str(data_path)
+    np.save(d / "ops.npy", ops)
+    if with_reg:
+        np.save(d / "reg_outputs.npy", {
+            "yoff": np.zeros(5, np.int64), "xoff": np.zeros(5, np.int64),
+            "yoff1": None, "xoff1": None, "bidiphase": 0,
+        })
+    if with_binary:
+        np.zeros((5, 8, 6), np.int16).tofile(d / "data.bin")
+    return d
+
+
+def test_can_open_matches_only_binaryless_reg_dir_with_raw(tmp_path):
+    raw = tmp_path / "raw.tif"
+    raw.write_bytes(b"x")  # just needs to exist for _resolve_raw_path
+
+    ok = _make_plane_dir(tmp_path / "a", with_binary=False, with_reg=True, data_path=raw)
+    assert RegisteredStreamArray.can_open(ok) is True
+    # also accepts the ops.npy path itself
+    assert RegisteredStreamArray.can_open(ok / "ops.npy") is True
+
+
+def test_can_open_rejects_binary_present(tmp_path):
+    raw = tmp_path / "raw.tif"; raw.write_bytes(b"x")
+    d = _make_plane_dir(tmp_path / "b", with_binary=True, with_reg=True, data_path=raw)
+    # a real binary is present -> defer to Suite2pArray
+    assert RegisteredStreamArray.can_open(d) is False
+
+
+def test_can_open_rejects_missing_pieces(tmp_path):
+    raw = tmp_path / "raw.tif"; raw.write_bytes(b"x")
+    no_reg = _make_plane_dir(tmp_path / "c", with_binary=False, with_reg=False, data_path=raw)
+    assert RegisteredStreamArray.can_open(no_reg) is False          # no reg_outputs.npy
+    no_raw = _make_plane_dir(tmp_path / "d", with_binary=False, with_reg=True, data_path=None)
+    assert RegisteredStreamArray.can_open(no_raw) is False          # no data_path
+    missing_raw = _make_plane_dir(
+        tmp_path / "e", with_binary=False, with_reg=True, data_path=tmp_path / "gone.tif"
+    )
+    assert RegisteredStreamArray.can_open(missing_raw) is False     # data_path not on disk
+    assert RegisteredStreamArray.can_open(tmp_path / "raw.tif") is False  # a plain file
+    assert RegisteredStreamArray.can_open(tmp_path / "does_not_exist") is False
+
+
+def test_dispatch_routes_streaming_dir_here_binary_dir_to_suite2p(tmp_path):
+    from mbo_utilities.lazy_array import _dispatch
+
+    raw = tmp_path / "raw.tif"; raw.write_bytes(b"x")
+    streaming = _make_plane_dir(tmp_path / "s", with_binary=False, with_reg=True, data_path=raw)
+    binary = _make_plane_dir(tmp_path / "bin", with_binary=True, with_reg=True, data_path=raw)
+
+    assert _dispatch(streaming).__name__ == "RegisteredStreamArray"
+    # no regression: a real binary suite2p dir still routes to Suite2pArray
+    assert _dispatch(binary).__name__ == "Suite2pArray"
+
+
+def _synthetic_movie(N=300, Ly=96, Lx=96, seed=1):
+    rng = np.random.default_rng(seed)
+    yy, xx = np.mgrid[0:Ly, 0:Lx]
+    base = np.zeros((Ly, Lx), np.float32)
+    for cy, cx, amp in [(28, 30, 1800), (60, 58, 2400), (45, 72, 2000)]:
+        base += amp * np.exp(-(((yy - cy) ** 2 + (xx - cx) ** 2) / (2 * 6.0 ** 2)))
+    base += 300
+    sh = rng.integers(-2, 3, size=(N, 2))
+    mov = np.empty((N, Ly, Lx), np.int16)
+    for i, (dy, dx) in enumerate(sh):
+        mov[i] = np.roll(base, (dy, dx), axis=(0, 1)).astype(np.int16)
+    return mov
+
+
+@pytest.mark.skipif(not _HAS_SUITE2P, reason="suite2p (and cv2) required")
+def test_imread_opens_registered_view_and_frames_match(tmp_path):
+    """Register synthetic data via streaming, then mbo.imread the plane dir and
+    confirm it returns a registered view whose frames equal the reconstitution."""
+    import tifffile
+    import torch
+    import mbo_utilities as mbo
+    from lbm_suite2p_python.default_ops import default_ops
+    from lbm_suite2p_python.run_lsp import run_plane_stream
+
+    mov = _synthetic_movie()
+    N, Ly, Lx = mov.shape
+    # keep raw and outputs in separate trees (as a real run does)
+    raw_dir = tmp_path / "raw"; raw_dir.mkdir()
+    raw_tif = raw_dir / "raw.tif"
+    tifffile.imwrite(raw_tif, mov)
+    arr = mbo.imread(raw_tif)  # 5D TiffArray (N,1,1,Ly,Lx)
+
+    plane_dir = tmp_path / "out" / "zplane01"
+    plane_dir.mkdir(parents=True)
+    ops = default_ops()
+    ops.update({
+        "Ly": Ly, "Lx": Lx, "nframes": N, "nframes_chan1": N,
+        "save_path": str(plane_dir), "ops_path": str(plane_dir / "ops.npy"),
+        "do_registration": 1, "roidetect": 0, "fs": 10.0, "tau": 1.0,
+        "block_size": [32, 32], "torch_device": "cpu", "plane": 1,
+        "data_path": str(raw_tif),
+    })
+    run_plane_stream(ops, arr, 0)
+
+    # imread dispatches the plane dir to the registered view
+    assert type(mbo.imread(plane_dir)).__name__ == "RegisteredStreamArray"
+
+    # pin the device for the frame comparison (imread auto-picks cuda when
+    # available, and cross-device nonrigid interpolation differs by ~1 px).
+    from lbm_suite2p_python.streaming_array import RegisteredStreamArray
+    rsa = RegisteredStreamArray(plane_dir, device=torch.device("cpu"))
+    assert rsa._shape5d() == (N, 1, 1, Ly, Lx)
+    assert rsa.dtype == np.int16
+    assert rsa.metadata.get("fs") == 10.0
+    assert rsa.nt == N and rsa.nz == 1
+
+    # frames equal the direct reconstitution, and differ from the raw movie
+    ref = StreamingBinaryFile.from_run(arr, plane_dir, plane_index=0, device=torch.device("cpu"))
+    ref_full = ref[:]
+    assert not np.array_equal(ref_full, mov)
+
+    # __getitem__ follows numpy 5D semantics against a reference built from the
+    # registered stack (the GUI squeezes the singleton C/Z for display).
+    ref5 = ref_full[:, None, None, :, :]
+    assert np.array_equal(rsa[10], ref5[10])                      # (1, 1, Ly, Lx)
+    assert np.array_equal(rsa[2:8], ref5[2:8])
+    assert np.array_equal(rsa[2:8, 0, 0, 10:20, 5:15], ref5[2:8, 0, 0, 10:20, 5:15])
+    assert np.array_equal(rsa[7, 0, 0], ref5[7, 0, 0])
+    assert rsa[7, 0, 0].shape == (Ly, Lx)
+
+    # the z-stats tab indexes with a strided time slice (this was the GUI crash);
+    # phasecorr-view-style (t_slice, c, z, :, :) must also work.
+    assert np.array_equal(rsa[::25, 0, 0, :, :], ref5[::25, 0, 0, :, :])
+    assert rsa[::25, 0, 0, :, :].shape[0] == len(range(0, N, 25))

--- a/uv.lock
+++ b/uv.lock
@@ -1600,7 +1600,7 @@ wheels = [
 
 [[package]]
 name = "lbm-suite2p-python"
-version = "3.2.2"
+version = "3.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "mbo-utilities" },

--- a/uv.lock
+++ b/uv.lock
@@ -32,128 +32,12 @@ wheels = [
 ]
 
 [[package]]
-name = "annotated-doc"
-version = "0.0.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
-]
-
-[[package]]
-name = "annotated-types"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
-]
-
-[[package]]
-name = "anyio"
-version = "4.14.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "idna" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/b5/001890774a9552aff22502b8da382593109ce0c95314abaebbb116567545/anyio-4.14.0.tar.gz", hash = "sha256:b47c1f9ccf73e67021df785332508f99379c68fa7d0684e8e3492cb1d4b23f89", size = 253586, upload-time = "2026-06-15T22:00:49.021Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/16/9826f089383c593cdfc4a6e5aca94d9e91ae1692c57af82c3b2aa5e810f7/anyio-4.14.0-py3-none-any.whl", hash = "sha256:dd9b7a2a9799ed6552fde617b2c5df02b7fdd7d88392fc48101e51bae46164d9", size = 123506, upload-time = "2026-06-15T22:00:47.595Z" },
-]
-
-[[package]]
-name = "anywidget"
-version = "0.11.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ipywidgets" },
-    { name = "psygnal" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/79/31/0491d707c674b34267f55d96d6a7148e55e7b6718a271686232cf295fbe2/anywidget-0.11.0.tar.gz", hash = "sha256:6695fbef9449cf8c27f421b96c5837aa37f909ec1f60cfa33add333e1b70b169", size = 426999, upload-time = "2026-04-27T23:42:09.576Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/c2/8fec8e8e2eb920cc2280f569144080cd58622a2eda83bfa4c0c354a63264/anywidget-0.11.0-py3-none-any.whl", hash = "sha256:c574d9acc6503ad27b37a9acea48f957a8ba7c9c9876cfcb37898931c098ce9d", size = 317341, upload-time = "2026-04-27T23:42:08.356Z" },
-]
-
-[[package]]
-name = "app-model"
-version = "0.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "in-n-out" },
-    { name = "psygnal" },
-    { name = "pydantic" },
-    { name = "pydantic-compat" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8d/23/a9537fd7021e8b6ea7db96b73e66fe61e809a3b23338de07d1176e69e4ee/app_model-0.4.0.tar.gz", hash = "sha256:ccf667999f6c659e921ca3490b6da176971e67cf2f41abc34e33caa8cfa18573", size = 120529, upload-time = "2025-06-20T17:41:08.943Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/fa/d7f4ae02a3b115abdf561d05ba8d5cdf9e3b2b5724b45d91e6cf08c163c3/app_model-0.4.0-py3-none-any.whl", hash = "sha256:5b1d69ee023d955b0c7a525771fd2fc02ff9d82cd2f12a982949423c3a901210", size = 65710, upload-time = "2025-06-20T17:41:07.696Z" },
-]
-
-[[package]]
-name = "appdirs"
-version = "1.4.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/d8/05696357e0311f5b5c316d7b95f46c669dd9c15aaeecbb48c7d0aeb88c40/appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41", size = 13470, upload-time = "2020-05-11T07:59:51.037Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/00/2344469e2084fb287c2e0b57b72910309874c3245463acd6cf5e3db69324/appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128", size = 9566, upload-time = "2020-05-11T07:59:49.499Z" },
-]
-
-[[package]]
 name = "appnope"
 version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/5d/752690df9ef5b76e169e68d6a129fa6d08a7100ca7f754c89495db3c6019/appnope-0.1.4.tar.gz", hash = "sha256:1de3860566df9caf38f01f86f65e0e13e379af54f9e4bee1e66b48f2efffd1ee", size = 4170, upload-time = "2024-02-06T09:43:11.258Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/29/5ecc3a15d5a33e31b26c11426c45c501e439cb865d0bff96315d86443b78/appnope-0.1.4-py2.py3-none-any.whl", hash = "sha256:502575ee11cd7a28c0205f379b525beefebab9d161b7c964670864014ed7213c", size = 4321, upload-time = "2024-02-06T09:43:09.663Z" },
-]
-
-[[package]]
-name = "argon2-cffi"
-version = "25.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "argon2-cffi-bindings" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706, upload-time = "2025-06-03T06:55:32.073Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl", hash = "sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741", size = 14657, upload-time = "2025-06-03T06:55:30.804Z" },
-]
-
-[[package]]
-name = "argon2-cffi-bindings"
-version = "25.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cffi" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/2d/db8af0df73c1cf454f71b2bbe5e356b8c1f8041c979f505b3d3186e520a9/argon2_cffi_bindings-25.1.0.tar.gz", hash = "sha256:b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d", size = 1783441, upload-time = "2025-07-30T10:02:05.147Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/57/96b8b9f93166147826da5f90376e784a10582dd39a393c99bb62cfcf52f0/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:aecba1723ae35330a008418a91ea6cfcedf6d31e5fbaa056a166462ff066d500", size = 54121, upload-time = "2025-07-30T10:01:50.815Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/08/a9bebdb2e0e602dde230bdde8021b29f71f7841bd54801bcfd514acb5dcf/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2630b6240b495dfab90aebe159ff784d08ea999aa4b0d17efa734055a07d2f44", size = 29177, upload-time = "2025-07-30T10:01:51.681Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7aef0c91e2c0fbca6fc68e7555aa60ef7008a739cbe045541e438373bc54d2b0", size = 31090, upload-time = "2025-07-30T10:01:53.184Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/93/44365f3d75053e53893ec6d733e4a5e3147502663554b4d864587c7828a7/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e021e87faa76ae0d413b619fe2b65ab9a037f24c60a1e6cc43457ae20de6dc6", size = 81246, upload-time = "2025-07-30T10:01:54.145Z" },
-    { url = "https://files.pythonhosted.org/packages/09/52/94108adfdd6e2ddf58be64f959a0b9c7d4ef2fa71086c38356d22dc501ea/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3e924cfc503018a714f94a49a149fdc0b644eaead5d1f089330399134fa028a", size = 87126, upload-time = "2025-07-30T10:01:55.074Z" },
-    { url = "https://files.pythonhosted.org/packages/72/70/7a2993a12b0ffa2a9271259b79cc616e2389ed1a4d93842fac5a1f923ffd/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87b72589133f0346a1cb8d5ecca4b933e3c9b64656c9d175270a000e73b288d", size = 80343, upload-time = "2025-07-30T10:01:56.007Z" },
-    { url = "https://files.pythonhosted.org/packages/78/9a/4e5157d893ffc712b74dbd868c7f62365618266982b64accab26bab01edc/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1db89609c06afa1a214a69a462ea741cf735b29a57530478c06eb81dd403de99", size = 86777, upload-time = "2025-07-30T10:01:56.943Z" },
-    { url = "https://files.pythonhosted.org/packages/74/cd/15777dfde1c29d96de7f18edf4cc94c385646852e7c7b0320aa91ccca583/argon2_cffi_bindings-25.1.0-cp39-abi3-win32.whl", hash = "sha256:473bcb5f82924b1becbb637b63303ec8d10e84c8d241119419897a26116515d2", size = 27180, upload-time = "2025-07-30T10:01:57.759Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:a98cd7d17e9f7ce244c0803cad3c23a7d379c301ba618a5fa76a67d116618b98", size = 31715, upload-time = "2025-07-30T10:01:58.56Z" },
-    { url = "https://files.pythonhosted.org/packages/42/b9/f8d6fa329ab25128b7e98fd83a3cb34d9db5b059a9847eddb840a0af45dd/argon2_cffi_bindings-25.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:b0fdbcf513833809c882823f98dc2f931cf659d9a1429616ac3adebb49f5db94", size = 27149, upload-time = "2025-07-30T10:01:59.329Z" },
-]
-
-[[package]]
-name = "arrow"
-version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "python-dateutil" },
-    { name = "tzdata" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/33/032cdc44182491aa708d06a68b62434140d8c50820a087fac7af37703357/arrow-1.4.0.tar.gz", hash = "sha256:ed0cc050e98001b8779e84d461b0098c4ac597e88704a655582b21d116e526d7", size = 152931, upload-time = "2025-10-18T17:46:46.761Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/c9/d7977eaacb9df673210491da99e6a247e93df98c715fc43fd136ce1d3d33/arrow-1.4.0-py3-none-any.whl", hash = "sha256:749f0769958ebdc79c173ff0b0670d59051a535fa26e8eba02953dc19eb43205", size = 68797, upload-time = "2025-10-18T17:46:45.663Z" },
 ]
 
 [[package]]
@@ -172,15 +56,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/be/a5/8e3f9b6771b0b408517c82d97aed8f2036509bc247d46114925e32fe33f0/asttokens-3.0.1.tar.gz", hash = "sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7", size = 62308, upload-time = "2025-11-15T16:43:48.578Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl", hash = "sha256:15a3ebc0f43c2d0a50eeafea25e19046c68398e487b9f1f5b517f7c0f40f976a", size = 27047, upload-time = "2025-11-15T16:43:16.109Z" },
-]
-
-[[package]]
-name = "async-lru"
-version = "2.3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e8/1f/989ecfef8e64109a489fff357450cb73fa73a865a92bd8c272170a6922c2/async_lru-2.3.0.tar.gz", hash = "sha256:89bdb258a0140d7313cf8f4031d816a042202faa61d0ab310a0a538baa1c24b6", size = 16332, upload-time = "2026-03-19T01:04:32.413Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/e2/c2e3abf398f80732e58b03be77bde9022550d221dd8781bf586bd4d97cc1/async_lru-2.3.0-py3-none-any.whl", hash = "sha256:eea27b01841909316f2cc739807acea1c623df2be8c5cfad7583286397bb8315", size = 8403, upload-time = "2026-03-19T01:04:30.883Z" },
 ]
 
 [[package]]
@@ -212,49 +87,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
-]
-
-[[package]]
-name = "bleach"
-version = "6.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "webencodings" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/48/3c/e12ac860709702bd5ebeb9b56a4fe334f1001246ee1b8f2b7ee28912df7d/bleach-6.4.0.tar.gz", hash = "sha256:4202482733d85cedd04e59fcb2f89f4e4c7c385a78d3c3c23c30446843a37452", size = 204857, upload-time = "2026-06-05T13:01:13.734Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/9d/40b6267367182187139a4000b82a3b287d84d745bccd808e75d916920e9d/bleach-6.4.0-py3-none-any.whl", hash = "sha256:4b6b6a54fff2e69a3dde9d21cc6301220bee3c3cb792187d11403fd795031081", size = 165109, upload-time = "2026-06-05T13:01:12.504Z" },
-]
-
-[package.optional-dependencies]
-css = [
-    { name = "tinycss2" },
-]
-
-[[package]]
-name = "build"
-version = "1.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "os_name == 'nt'" },
-    { name = "packaging" },
-    { name = "pyproject-hooks" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/78/e0/df5e171f685f82f37b12e1f208064e24244911079d7b767447d1af7e0d70/build-1.5.0.tar.gz", hash = "sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647", size = 89796, upload-time = "2026-04-30T03:18:25.17Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl", hash = "sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f", size = 26018, upload-time = "2026-04-30T03:18:23.644Z" },
-]
-
-[[package]]
-name = "cachey"
-version = "0.2.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "heapdict" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/9c/e3c959c1601013bf8a72e8bf91ea1ebc6fe8a2305bd2324b039ee0403277/cachey-0.2.1.tar.gz", hash = "sha256:0310ba8afe52729fa7626325c8d8356a8421c434bf887ac851e58dcf7cf056a6", size = 6461, upload-time = "2020-03-11T15:34:08.721Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/f0/e24f3e5d5d539abeb783087b87c26cfb99c259f1126700569e000243745a/cachey-0.2.1-py3-none-any.whl", hash = "sha256:49cf8528496ce3f99d47f1bd136b7c88237e55347a15d880f47cefc0615a83c3", size = 6415, upload-time = "2020-03-11T15:34:07.347Z" },
 ]
 
 [[package]]
@@ -555,11 +387,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/02/17/b82b537a30be67ba178fc0b0fbda8fcbaeda188fb039d6ad8a84e89353a2/dask-2026.6.0-py3-none-any.whl", hash = "sha256:1539859071065dca379ca592ff76e911cd7965dc466da0040354ab466179189b", size = 1488995, upload-time = "2026-06-11T17:48:41.008Z" },
 ]
 
-[package.optional-dependencies]
-array = [
-    { name = "numpy" },
-]
-
 [[package]]
 name = "debugpy"
 version = "1.8.21"
@@ -584,24 +411,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/60/8b/32f9823da46cde7df2087faa08cd98d01b908f8dcab982cdba9c84e85355/decorator-5.3.1.tar.gz", hash = "sha256:4cbcdd55a6efadb9dbea26b858f4fb3264567b52d69ca0d25b721b553f60ea82", size = 58084, upload-time = "2026-05-18T06:03:28.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/05/7f/798705f5296a58ca505d600456748d1be48078eac8a7050d8a98bc9edb89/decorator-5.3.1-py3-none-any.whl", hash = "sha256:f47fe6fdbd2edd623ecfe36875d37aba411624e2670dd395dddae1358689bb3c", size = 10365, upload-time = "2026-05-18T06:03:26.517Z" },
-]
-
-[[package]]
-name = "defusedxml"
-version = "0.7.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
-]
-
-[[package]]
-name = "docstring-parser"
-version = "0.18.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
 ]
 
 [[package]]
@@ -714,30 +523,6 @@ wheels = [
 ]
 
 [[package]]
-name = "flexcache"
-version = "0.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/55/b0/8a21e330561c65653d010ef112bf38f60890051d244ede197ddaa08e50c1/flexcache-0.3.tar.gz", hash = "sha256:18743bd5a0621bfe2cf8d519e4c3bfdf57a269c15d1ced3fb4b64e0ff4600656", size = 15816, upload-time = "2024-03-09T03:21:07.555Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl", hash = "sha256:d43c9fea82336af6e0115e308d9d33a185390b8346a017564611f1466dcd2e32", size = 13263, upload-time = "2024-03-09T03:21:05.635Z" },
-]
-
-[[package]]
-name = "flexparser"
-version = "0.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/82/99/b4de7e39e8eaf8207ba1a8fa2241dd98b2ba72ae6e16960d8351736d8702/flexparser-0.4.tar.gz", hash = "sha256:266d98905595be2ccc5da964fe0a2c3526fbbffdc45b65b3146d75db992ef6b2", size = 31799, upload-time = "2024-11-07T02:00:56.249Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/5e/3be305568fe5f34448807976dc82fc151d76c3e0e03958f34770286278c1/flexparser-0.4-py3-none-any.whl", hash = "sha256:3738b456192dcb3e15620f324c447721023c0293f6af9955b481e91d00179846", size = 27625, upload-time = "2024-11-07T02:00:54.523Z" },
-]
-
-[[package]]
 name = "fonttools"
 version = "4.63.0"
 source = { registry = "https://pypi.org/simple" }
@@ -760,15 +545,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/1f/a98a30a814b9ddef3a2e706025f90b9e0bc94890e6cb15254bc86547d11a/fonttools-4.63.0-cp313-cp313-win32.whl", hash = "sha256:85be818f5506e8a7753153def2c9550178f0ecae6a47b5e0e8dbb23f7cc90380", size = 2291313, upload-time = "2026-05-14T12:03:45.594Z" },
     { url = "https://files.pythonhosted.org/packages/92/46/5177b01f3b4abfdd4409f31cca4ab279c9343a26efbe9ec78c97fc612e02/fonttools-4.63.0-cp313-cp313-win_amd64.whl", hash = "sha256:ba04cb5891d4c0c21b6da95eda8d7b090021508a294fff33464fc7d241e0856b", size = 2342299, upload-time = "2026-05-14T12:03:47.414Z" },
     { url = "https://files.pythonhosted.org/packages/2c/47/c99d5268f354002ce80f8d029cd9d7d872969da1de8b93d32de4dc56d6f4/fonttools-4.63.0-py3-none-any.whl", hash = "sha256:445af2eab030a16b9171ea8bdda7ebf7d96bda2df88ee182a464252f6e05e20d", size = 1164562, upload-time = "2026-05-14T12:04:29.092Z" },
-]
-
-[[package]]
-name = "fqdn"
-version = "1.5.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/30/3e/a80a8c077fd798951169626cde3e239adeba7dab75deb3555716415bd9b0/fqdn-1.5.1.tar.gz", hash = "sha256:105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f", size = 6015, upload-time = "2021-03-11T07:16:29.08Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/58/8acf1b3e91c58313ce5cb67df61001fc9dcd21be4fadb76c1a2d540e09ed/fqdn-1.5.1-py3-none-any.whl", hash = "sha256:3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014", size = 9121, upload-time = "2021-03-11T07:16:28.351Z" },
 ]
 
 [[package]]
@@ -870,15 +646,6 @@ wheels = [
 ]
 
 [[package]]
-name = "h11"
-version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
-]
-
-[[package]]
 name = "h5py"
 version = "3.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -906,49 +673,12 @@ wheels = [
 ]
 
 [[package]]
-name = "heapdict"
-version = "1.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5a/9b/d8963ae7e388270b695f3b556b6dc9adb70ae9618fba09aa1e7b1886652d/HeapDict-1.0.1.tar.gz", hash = "sha256:8495f57b3e03d8e46d5f1b2cc62ca881aca392fd5cc048dc0aa2e1a6d23ecdb6", size = 4274, upload-time = "2019-09-09T18:57:02.154Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/9d/cd4777dbcf3bef9d9627e0fe4bc43d2e294b1baeb01d0422399d5e9de319/HeapDict-1.0.1-py3-none-any.whl", hash = "sha256:6065f90933ab1bb7e50db403b90cab653c853690c5992e69294c2de2b253fc92", size = 3917, upload-time = "2019-09-09T18:57:00.821Z" },
-]
-
-[[package]]
 name = "hsluv"
 version = "5.0.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ac/81/af16607fa045724e515579d312577261b436f36f419e7c677e7e88fcc943/hsluv-5.0.4.tar.gz", hash = "sha256:2281f946427a882010042844a38c7bbe9e0d0aaf9d46babe46366ed6f169b72e", size = 543090, upload-time = "2023-09-11T21:46:52.022Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/96/36/5bddefea3d7adf22a64f9aa9701492f8a9fe6948223f5cf2602c22ec9be7/hsluv-5.0.4-py2.py3-none-any.whl", hash = "sha256:0138bd10038e2ee1b13eecae9a7d49d4ec8c320b1d7eb4f860832c792e3e4567", size = 5252, upload-time = "2023-09-11T21:46:50.407Z" },
-]
-
-[[package]]
-name = "httpcore"
-version = "1.0.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "h11" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
-]
-
-[[package]]
-name = "httpx"
-version = "0.28.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "certifi" },
-    { name = "httpcore" },
-    { name = "idna" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -1069,45 +799,12 @@ wheels = [
 ]
 
 [[package]]
-name = "in-n-out"
-version = "0.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/af/08/07edfac98a38ab0208557524cbdd94a296f565b0558417ccb2c03d14a6ea/in_n_out-0.2.1.tar.gz", hash = "sha256:43cde2b7de981d41a6d70618a2b7bd989481095922a53ead4dc75f2bbd5dffea", size = 26026, upload-time = "2024-04-22T18:56:50.418Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/06/711a4d105ad3d01d3ef351a1039bb5cc517a57dbf377d7da9a0808e34c77/in_n_out-0.2.1-py3-none-any.whl", hash = "sha256:343e81edb27cf41ec946134a92964f408465abdf6a065c6c55fe96f53bc3c8b7", size = 19951, upload-time = "2024-04-22T18:56:48.572Z" },
-]
-
-[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
-]
-
-[[package]]
-name = "intel-cmplr-lib-ur"
-version = "2026.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "umf" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/6d/b981353d0ba8dc6d54510aba97f67ddce3872a693f41841bb77a120f512c/intel_cmplr_lib_ur-2026.0.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:5fb75293e7f1f8377cda3aac44f4e7c0c1dd38e281fecefa76ca1459382763a4", size = 31565700, upload-time = "2026-04-24T14:10:16.369Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/0f/427cee2d63934966338cc58b3782819c196b90407d60c58ea708be78eb50/intel_cmplr_lib_ur-2026.0.0-py2.py3-none-win_amd64.whl", hash = "sha256:db2639ff3b1467edd5f5872a6005564ff4d9685b4fa68f5a4b42230a0d8a1562", size = 1305315, upload-time = "2026-04-24T14:12:08.402Z" },
-]
-
-[[package]]
-name = "intel-openmp"
-version = "2026.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "intel-cmplr-lib-ur" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/52/ad8da758c96299c27ac1f0345979f9202a517c4f18ef6a1e9b7a781d6948/intel_openmp-2026.0.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:c4605c63840d6dc0188610f9d0dcc5ae6c73c988f98c36c4bd807bcbd0de73bb", size = 57250534, upload-time = "2026-04-24T14:10:11.769Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/48/32b1c24d3f1e4f47495d29bda38002384ae03a9ab709b575dda31842c0a4/intel_openmp-2026.0.0-py2.py3-none-win_amd64.whl", hash = "sha256:d1f18c4e1be8426da117252a4fb8e5d72be44807b0251fcea23e2fa7b7d85981", size = 30721954, upload-time = "2026-04-24T14:11:48.06Z" },
 ]
 
 [[package]]
@@ -1169,34 +866,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ipywidgets"
-version = "8.1.8"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "comm" },
-    { name = "ipython" },
-    { name = "jupyterlab-widgets" },
-    { name = "traitlets" },
-    { name = "widgetsnbextension" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/ae/c5ce1edc1afe042eadb445e95b0671b03cee61895264357956e61c0d2ac0/ipywidgets-8.1.8.tar.gz", hash = "sha256:61f969306b95f85fba6b6986b7fe45d73124d1d9e3023a8068710d47a22ea668", size = 116739, upload-time = "2025-11-01T21:18:12.393Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/6d/0d9848617b9f753b87f214f1c682592f7ca42de085f564352f10f0843026/ipywidgets-8.1.8-py3-none-any.whl", hash = "sha256:ecaca67aed704a338f88f67b1181b58f821ab5dc89c1f0f5ef99db43c1c2921e", size = 139808, upload-time = "2025-11-01T21:18:10.956Z" },
-]
-
-[[package]]
-name = "isoduration"
-version = "20.11.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "arrow" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/1a/3c8edc664e06e6bd06cce40c6b22da5f1429aa4224d0c590f3be21c91ead/isoduration-20.11.0.tar.gz", hash = "sha256:ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9", size = 11649, upload-time = "2020-11-01T11:00:00.312Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/55/e5326141505c5d5e34c5e0935d2908a74e4561eca44108fbfb9c13d2911a/isoduration-20.11.0-py3-none-any.whl", hash = "sha256:b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042", size = 11321, upload-time = "2020-11-01T10:59:58.02Z" },
-]
-
-[[package]]
 name = "jedi"
 version = "0.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1230,24 +899,6 @@ wheels = [
 ]
 
 [[package]]
-name = "json5"
-version = "0.15.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e4/7d/05c46a96a78147ae3bf99c2f4169ce144a70220b8d6fcd56f6ec368b8ce9/json5-0.15.0.tar.gz", hash = "sha256:7424d1f1eb1d56da6e3d70643f53619862b4ce81440bdb8ecfd6f875e5ba4a71", size = 53278, upload-time = "2026-06-19T20:08:27.716Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/be/59527c99478aade6bb33a68d72e6e18dd4e6ff6eacfc7d01bdb15bc76912/json5-0.15.0-py3-none-any.whl", hash = "sha256:56636a30c0e8a4665fe2179c0212f32eae3796dea89ea6f649b9436ecdb39618", size = 36570, upload-time = "2026-06-19T20:08:26.748Z" },
-]
-
-[[package]]
-name = "jsonpointer"
-version = "3.1.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/18/c7/af399a2e7a67fd18d63c40c5e62d3af4e67b836a2107468b6a5ea24c4304/jsonpointer-3.1.1.tar.gz", hash = "sha256:0b801c7db33a904024f6004d526dcc53bbb8a4a0f4e32bfd10beadf60adf1900", size = 9068, upload-time = "2026-03-23T22:32:32.458Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/6a/a83720e953b1682d2d109d3c2dbb0bc9bf28cc1cbc205be4ef4be5da709d/jsonpointer-3.1.1-py3-none-any.whl", hash = "sha256:8ff8b95779d071ba472cf5bc913028df06031797532f08a7d5b602d8b2a488ca", size = 7659, upload-time = "2026-03-23T22:32:31.568Z" },
-]
-
-[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1262,19 +913,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
 ]
 
-[package.optional-dependencies]
-format-nongpl = [
-    { name = "fqdn" },
-    { name = "idna" },
-    { name = "isoduration" },
-    { name = "jsonpointer" },
-    { name = "rfc3339-validator" },
-    { name = "rfc3986-validator" },
-    { name = "rfc3987-syntax" },
-    { name = "uri-template" },
-    { name = "webcolors" },
-]
-
 [[package]]
 name = "jsonschema-specifications"
 version = "2025.9.1"
@@ -1285,19 +923,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
-]
-
-[[package]]
-name = "jupyter-builder"
-version = "1.0.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jupyter-core" },
-    { name = "traitlets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/45/d0df8b43c10a61529c0f4a8af5e19ebe108f0c3af8f57e0fc358969907af/jupyter_builder-1.0.2.tar.gz", hash = "sha256:6155d78a5325010532a6419ffcba89eac643fd1aa56ea83115e661924d6f6aab", size = 968638, upload-time = "2026-06-12T02:33:25.767Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/b6/c418e0b3256f67c04933566b80bfce947350682db92c4b786a8653db32d6/jupyter_builder-1.0.2-py3-none-any.whl", hash = "sha256:b024f65d36e1d530542db597b00dd513261aa59842e0d0fbbb1015a9f1935e9c", size = 910789, upload-time = "2026-06-12T02:33:23.317Z" },
 ]
 
 [[package]]
@@ -1347,153 +972,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/02/49/9d1284d0dc65e2c757b74c6687b6d319b02f822ad039e5c512df9194d9dd/jupyter_core-5.9.1.tar.gz", hash = "sha256:4d09aaff303b9566c3ce657f580bd089ff5c91f5f89cf7d8846c3cdf465b5508", size = 89814, upload-time = "2025-10-16T19:19:18.444Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl", hash = "sha256:ebf87fdc6073d142e114c72c9e29a9d7ca03fad818c5d300ce2adc1fb0743407", size = 29032, upload-time = "2025-10-16T19:19:16.783Z" },
-]
-
-[[package]]
-name = "jupyter-events"
-version = "0.12.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jsonschema", extra = ["format-nongpl"] },
-    { name = "packaging" },
-    { name = "python-json-logger" },
-    { name = "pyyaml" },
-    { name = "referencing" },
-    { name = "rfc3339-validator" },
-    { name = "rfc3986-validator" },
-    { name = "traitlets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/18/f8/475c4241b2b75af0deaae453ed003c6c851766dbc44d332d8baf245dc931/jupyter_events-0.12.1.tar.gz", hash = "sha256:faff25f77218335752f35f23c5fe6e4a392a7bd99a5939ccb9b8fbf594636cf3", size = 62854, upload-time = "2026-04-20T23:17:50.66Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/6c/6fcde0c8f616ed360ffd3587f7db9e225a7e62b583a04494d2f069cf64ea/jupyter_events-0.12.1-py3-none-any.whl", hash = "sha256:c366585253f537a627da52fa7ca7410c5b5301fe893f511e7b077c2d93ec8bcf", size = 19512, upload-time = "2026-04-20T23:17:48.927Z" },
-]
-
-[[package]]
-name = "jupyter-lsp"
-version = "2.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jupyter-server" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/36/ff/1e4a61f5170a9a1d978f3ac3872449de6c01fc71eaf89657824c878b1549/jupyter_lsp-2.3.1.tar.gz", hash = "sha256:fdf8a4aa7d85813976d6e29e95e6a2c8f752701f926f2715305249a3829805a6", size = 55677, upload-time = "2026-04-02T08:10:06.749Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/e8/9d61dcbd1dce8ef418f06befd4ac084b4720429c26b0b1222bc218685eff/jupyter_lsp-2.3.1-py3-none-any.whl", hash = "sha256:71b954d834e85ff3096400554f2eefaf7fe37053036f9a782b0f7c5e42dadb81", size = 77513, upload-time = "2026-04-02T08:10:01.753Z" },
-]
-
-[[package]]
-name = "jupyter-rfb"
-version = "1.0.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anywidget" },
-    { name = "numpy" },
-    { name = "simplejpeg", marker = "implementation_name != 'pypy'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/12/65/5ad94b96f42bb88b87765184becf6513edaf9377cec7ecd6ec66dab81f16/jupyter_rfb-1.0.2.tar.gz", hash = "sha256:b77a9a464e2da6d0b345b3989f037c4db2fc0c34da3379b380c42baeb0b3abca", size = 24824, upload-time = "2026-03-24T15:11:16.892Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/89/d8a7ceff010ba38fdc345f7bc715e6152a70c6e28a68d4c7c0e1d943f420/jupyter_rfb-1.0.2-py3-none-any.whl", hash = "sha256:713c682e5a9c1ae32c3530053b53f3c9ddb66990f9315024e49f9a3db7d125f3", size = 27341, upload-time = "2026-03-24T15:11:15.656Z" },
-]
-
-[[package]]
-name = "jupyter-server"
-version = "2.20.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "argon2-cffi" },
-    { name = "jinja2" },
-    { name = "jupyter-client" },
-    { name = "jupyter-core" },
-    { name = "jupyter-events" },
-    { name = "jupyter-server-terminals" },
-    { name = "nbconvert" },
-    { name = "nbformat" },
-    { name = "packaging" },
-    { name = "prometheus-client" },
-    { name = "pywinpty", marker = "os_name == 'nt'" },
-    { name = "pyzmq" },
-    { name = "send2trash" },
-    { name = "terminado" },
-    { name = "tornado" },
-    { name = "traitlets" },
-    { name = "websocket-client" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/dc/db3a582633170186f8c8b31298d7eb26ad0eb031a1f53476c258b64eed05/jupyter_server-2.20.0.tar.gz", hash = "sha256:b5778ba337d8015a3dc2b80803ecdd5ac18d3797fddf61a50ea5fb472b4ebe14", size = 756523, upload-time = "2026-06-17T12:09:09.435Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/71/8c002223e873a870f5c41dc69b0a7c922301123e4a31d5d01ecb700aef77/jupyter_server-2.20.0-py3-none-any.whl", hash = "sha256:c3b67c93c471e947c18b5026f04f21614218adb706df8f48227d3ee8e0a7cdcc", size = 393143, upload-time = "2026-06-17T12:09:07.234Z" },
-]
-
-[[package]]
-name = "jupyter-server-terminals"
-version = "0.5.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pywinpty", marker = "os_name == 'nt'" },
-    { name = "terminado" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/a7/bcd0a9b0cbba88986fe944aaaf91bfda603e5a50bda8ed15123f381a3b2f/jupyter_server_terminals-0.5.4.tar.gz", hash = "sha256:bbda128ed41d0be9020349f9f1f2a4ab9952a73ed5f5ac9f1419794761fb87f5", size = 31770, upload-time = "2026-01-14T16:53:20.213Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/2d/6674563f71c6320841fc300911a55143925112a72a883e2ca71fba4c618d/jupyter_server_terminals-0.5.4-py3-none-any.whl", hash = "sha256:55be353fc74a80bc7f3b20e6be50a55a61cd525626f578dcb66a5708e2007d14", size = 13704, upload-time = "2026-01-14T16:53:18.738Z" },
-]
-
-[[package]]
-name = "jupyterlab"
-version = "4.6.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "async-lru" },
-    { name = "httpx" },
-    { name = "ipykernel" },
-    { name = "jinja2" },
-    { name = "jupyter-builder" },
-    { name = "jupyter-core" },
-    { name = "jupyter-lsp" },
-    { name = "jupyter-server" },
-    { name = "jupyterlab-server" },
-    { name = "notebook-shim" },
-    { name = "packaging" },
-    { name = "tornado" },
-    { name = "traitlets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/3c/1ebd737b860cdbe61eed71536d06aab4e1781fbdcf07ecd5a1afe05b8adf/jupyterlab-4.6.0.tar.gz", hash = "sha256:6a8b88f2aae7ed4d012c634fc957c1a27f3aa217c32f0ced0175fac9ee17f9e5", size = 28181861, upload-time = "2026-06-18T13:52:56.039Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/eb/aa48075d0aa3d0188db34ba2704f53791757743c0bb02e18c4eef989b6de/jupyterlab-4.6.0-py3-none-any.whl", hash = "sha256:b6938cb8a1ef3d43860ff4745a680c62cc0a9385f9672295bb56cd2e7cfeebe2", size = 17143447, upload-time = "2026-06-18T13:52:51.42Z" },
-]
-
-[[package]]
-name = "jupyterlab-pygments"
-version = "0.3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/90/51/9187be60d989df97f5f0aba133fa54e7300f17616e065d1ada7d7646b6d6/jupyterlab_pygments-0.3.0.tar.gz", hash = "sha256:721aca4d9029252b11cfa9d185e5b5af4d54772bb8072f9b7036f4170054d35d", size = 512900, upload-time = "2023-11-23T09:26:37.44Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/dd/ead9d8ea85bf202d90cc513b533f9c363121c7792674f78e0d8a854b63b4/jupyterlab_pygments-0.3.0-py3-none-any.whl", hash = "sha256:841a89020971da1d8693f1a99997aefc5dc424bb1b251fd6322462a1b8842780", size = 15884, upload-time = "2023-11-23T09:26:34.325Z" },
-]
-
-[[package]]
-name = "jupyterlab-server"
-version = "2.28.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "babel" },
-    { name = "jinja2" },
-    { name = "json5" },
-    { name = "jsonschema" },
-    { name = "jupyter-server" },
-    { name = "packaging" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d6/2c/90153f189e421e93c4bb4f9e3f59802a1f01abd2ac5cf40b152d7f735232/jupyterlab_server-2.28.0.tar.gz", hash = "sha256:35baa81898b15f93573e2deca50d11ac0ae407ebb688299d3a5213265033712c", size = 76996, upload-time = "2025-10-22T13:59:18.37Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/07/a000fe835f76b7e1143242ab1122e6362ef1c03f23f83a045c38859c2ae0/jupyterlab_server-2.28.0-py3-none-any.whl", hash = "sha256:e4355b148fdcf34d312bbbc80f22467d6d20460e8b8736bf235577dd18506968", size = 59830, upload-time = "2025-10-22T13:59:16.767Z" },
-]
-
-[[package]]
-name = "jupyterlab-widgets"
-version = "3.0.16"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/26/2d/ef58fed122b268c69c0aa099da20bc67657cdfb2e222688d5731bd5b971d/jupyterlab_widgets-3.0.16.tar.gz", hash = "sha256:423da05071d55cf27a9e602216d35a3a65a3e41cdf9c5d3b643b814ce38c19e0", size = 897423, upload-time = "2025-11-01T21:11:29.724Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/b5/36c712098e6191d1b4e349304ef73a8d06aed77e56ceaac8c0a306c7bda1/jupyterlab_widgets-3.0.16-py3-none-any.whl", hash = "sha256:45fa36d9c6422cf2559198e4db481aa243c7a32d9926b500781c830c80f7ecf8", size = 914926, upload-time = "2025-11-01T21:11:28.008Z" },
 ]
 
 [[package]]
@@ -1569,15 +1047,6 @@ wheels = [
 ]
 
 [[package]]
-name = "lark"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905", size = 382732, upload-time = "2025-10-27T18:25:56.653Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12", size = 113151, upload-time = "2025-10-27T18:25:54.882Z" },
-]
-
-[[package]]
 name = "latexcodec"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1600,7 +1069,7 @@ wheels = [
 
 [[package]]
 name = "lbm-suite2p-python"
-version = "3.2.3"
+version = "3.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "mbo-utilities" },
@@ -1653,7 +1122,7 @@ docs = [
 requires-dist = [
     { name = "cellpose", marker = "extra == 'cellpose'", specifier = ">=4.0.6" },
     { name = "lbm-suite2p-python", extras = ["rastermap", "cellpose"], marker = "extra == 'all'" },
-    { name = "mbo-utilities", specifier = ">=3.2.7" },
+    { name = "mbo-utilities", specifier = ">=3.3.0" },
     { name = "rastermap", marker = "extra == 'rastermap'" },
     { name = "setuptools", specifier = "<81" },
     { name = "suite2p", specifier = ">=1.0.0.1" },
@@ -1710,22 +1179,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2f/83/97b29fe05cb6ae28d2dbd30b81e2e402a3eed5f460c26e9eaa5895ceacf5/locket-1.0.0.tar.gz", hash = "sha256:5c0d4c052a8bbbf750e056a8e65ccd309086f4f0f18a2eac306a8dfa4112a632", size = 4350, upload-time = "2022-04-20T22:04:44.312Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl", hash = "sha256:b6c819a722f7b6bd955b80781788e4a66a55628b858d347536b7e81325a3a5e3", size = 4398, upload-time = "2022-04-20T22:04:42.23Z" },
-]
-
-[[package]]
-name = "magicgui"
-version = "0.10.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "docstring-parser" },
-    { name = "psygnal" },
-    { name = "qtpy" },
-    { name = "superqt", extra = ["iconify"] },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/9c/0d918ee0a9b31f16e9b76c1b86b81b5d4b7bc491354c76030b87790f0cab/magicgui-0.10.2.tar.gz", hash = "sha256:ae7a4cbb7ef2028b827b1877cf0b06743d756074fe6ef849391d62448ab7b65d", size = 20946219, upload-time = "2026-04-10T14:45:28.927Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/bb/5ba264d3ccc13294e74c48c3ef0c2e96b8b13765562628515654012cc47e/magicgui-0.10.2-py3-none-any.whl", hash = "sha256:0f304d4da1a4309ad15d38cb809ef73269cea73a3195ac944f38d7c56d8e0fd5", size = 128254, upload-time = "2026-04-10T14:45:27.173Z" },
 ]
 
 [[package]]
@@ -1850,9 +1303,10 @@ wheels = [
 
 [[package]]
 name = "mbo-utilities"
-version = "3.2.7"
+version = "3.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "click" },
     { name = "dask" },
     { name = "ffmpeg-python" },
     { name = "glfw", marker = "sys_platform != 'linux'" },
@@ -1860,43 +1314,29 @@ dependencies = [
     { name = "icecream" },
     { name = "imageio", extra = ["ffmpeg"] },
     { name = "imgui-bundle" },
-    { name = "ipykernel" },
-    { name = "ipywidgets" },
-    { name = "jupyter-rfb" },
-    { name = "jupyterlab" },
-    { name = "lbm-suite2p-python" },
     { name = "llvmlite" },
     { name = "matplotlib" },
     { name = "mbo-fastplotlib" },
-    { name = "mkl-fft" },
-    { name = "napari" },
-    { name = "napari-animation" },
-    { name = "napari-ome-zarr" },
     { name = "numba" },
     { name = "numpy" },
     { name = "opencv-python-headless" },
     { name = "pandas" },
     { name = "pygfx" },
-    { name = "pyqt6" },
-    { name = "pyqt6-sip" },
-    { name = "pyqtgraph" },
-    { name = "qtpy" },
+    { name = "pyqt6", marker = "sys_platform == 'linux'" },
+    { name = "pyqt6-sip", marker = "sys_platform == 'linux'" },
     { name = "rendercanvas" },
     { name = "scikit-image" },
     { name = "scipy" },
-    { name = "seaborn" },
     { name = "setuptools" },
-    { name = "suite2p" },
+    { name = "submitit" },
     { name = "tifffile" },
-    { name = "torch" },
-    { name = "torchvision" },
     { name = "tqdm" },
     { name = "wgpu" },
     { name = "zarr" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/69/44/4ee49068d2d733872d43dce3563651dd480bed8775d4fa28a129e9df526b/mbo_utilities-3.2.7.tar.gz", hash = "sha256:fd5227daf615ed418bc16f7596d0e3000c773de6810b4e205b778e42ff3a7c1d", size = 4100169, upload-time = "2026-06-17T15:35:57.726Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/b2/4e43877abff6c6305a749247ca20f6f92d3b949f158481b0c926dc036e4c/mbo_utilities-3.3.0.tar.gz", hash = "sha256:e37a692c21f10bd671be21b75d64dff036e994a84b527059a1403d72c609e96c", size = 4100314, upload-time = "2026-06-24T16:27:05.869Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/0b/f01ed0be655ceb98b00357c977ad242e35edf5c37e1dde7f1b121a03e4f1/mbo_utilities-3.2.7-py3-none-any.whl", hash = "sha256:843bdb1dedba35872dc2576b11cb468f5498b50800dd406f53d89409bca13e6d", size = 3880686, upload-time = "2026-06-17T15:35:55.861Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/1d/3109c15300cab3e20668e03c9989da32c65d682bfcd3620fb6633ea4f79e/mbo_utilities-3.3.0-py3-none-any.whl", hash = "sha256:478cd92e4f33b5db41709ed20e7d3e8a52ea962e2ed2a3936ea4aa0c236f047e", size = 3872660, upload-time = "2026-06-24T16:27:03.992Z" },
 ]
 
 [[package]]
@@ -1918,44 +1358,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
-]
-
-[[package]]
-name = "mistune"
-version = "3.3.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/04/5f/007786743f962224423753b78f7d7acb0f2ade46d1604f2e0fa2bedf9020/mistune-3.3.2.tar.gz", hash = "sha256:e12ee4f1e74336e91aa1141e35f913b337c40bdf7c0cc49f21fb853a27e8b62f", size = 111284, upload-time = "2026-06-23T00:29:28.568Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/43/894c2cbbcbdf53b57d1257a249811abe2ee9ab7ef76af301b40f1c054533/mistune-3.3.2-py3-none-any.whl", hash = "sha256:a678a56387d487db7368ede4647cb2ba1deff22ce61f92343e4ebe0ddfce4f2d", size = 61554, upload-time = "2026-06-23T00:29:27.088Z" },
-]
-
-[[package]]
-name = "mkl"
-version = "2026.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "intel-openmp" },
-    { name = "onemkl-license" },
-    { name = "tbb" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/97/06ad1072db8a3c4d1e6237badf660c4c754d2b513264996121c2b666d65d/mkl-2026.0.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:4a9525ddd671b422fedfc690dd9270beb65c8cbd47044b52d2a4e3f6162c9de6", size = 224036598, upload-time = "2026-04-24T14:12:43.717Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/2f/8a77106ef648cc1f04aa27e8b6c50cd82de38d1767801ef29cd75b8026e8/mkl-2026.0.0-py2.py3-none-win_amd64.whl", hash = "sha256:801c9cc748be81d8269bfec2495d02be38560fc7386439c18499ab3f32b06b3e", size = 180805356, upload-time = "2026-04-24T14:08:52.681Z" },
-]
-
-[[package]]
-name = "mkl-fft"
-version = "2.2.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mkl" },
-    { name = "numpy" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/27/b24cfbdd4d312f01be779be3f49aa31c14e7bdb33e11e2dc6ef66d439e14/mkl_fft-2.2.1-0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:a0f090c1b6b0ab0ed296ac70db33b5a6cc6747918f1529c6ddcab2fc4db03d0c", size = 158505, upload-time = "2026-05-12T22:27:48.476Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/c0/0ab5baf9bef0172d9e5864085d70aa4abeb589b0ef3724656529a1f08182/mkl_fft-2.2.1-0-cp312-cp312-win_amd64.whl", hash = "sha256:32c23ae73e8e4797e6b4d750cf0900f49d5efcd735ce7a67a16a91018c00fc1d", size = 144513, upload-time = "2026-05-12T22:28:03.569Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/67/b1de1dcab7b86d1c66a49859856df3076b7a1997de4665041e7fd5b5ff37/mkl_fft-2.2.1-0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:a643d08316a066661fce5e41d934d5bc7d08a62c72be8a3f0274a804510ac296", size = 155748, upload-time = "2026-05-12T22:28:18.265Z" },
-    { url = "https://files.pythonhosted.org/packages/64/ab/b8639cee10ba137368ed7a12c0b1e7262df533105cbd89056d8ca4c9263e/mkl_fft-2.2.1-0-cp313-cp313-win_amd64.whl", hash = "sha256:3252cbcd5071b1708ed256cc7ca72be386f08bb6dd8627bdf287e994a282676b", size = 144368, upload-time = "2026-05-12T22:28:43.997Z" },
 ]
 
 [[package]]
@@ -2006,123 +1408,6 @@ wheels = [
 ]
 
 [[package]]
-name = "napari"
-version = "0.6.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "app-model" },
-    { name = "appdirs" },
-    { name = "cachey" },
-    { name = "certifi" },
-    { name = "dask", extra = ["array"] },
-    { name = "imageio" },
-    { name = "jsonschema" },
-    { name = "lazy-loader" },
-    { name = "magicgui" },
-    { name = "napari-console" },
-    { name = "napari-plugin-engine" },
-    { name = "napari-svg" },
-    { name = "npe2" },
-    { name = "numpy" },
-    { name = "numpydoc" },
-    { name = "pandas" },
-    { name = "pillow" },
-    { name = "pint" },
-    { name = "psutil" },
-    { name = "psygnal" },
-    { name = "pydantic" },
-    { name = "pygments" },
-    { name = "pyopengl" },
-    { name = "pywin32", marker = "sys_platform == 'win32'" },
-    { name = "pyyaml" },
-    { name = "qtpy" },
-    { name = "scikit-image", extra = ["data"] },
-    { name = "scipy" },
-    { name = "superqt" },
-    { name = "tifffile" },
-    { name = "toolz" },
-    { name = "tqdm" },
-    { name = "typing-extensions" },
-    { name = "vispy" },
-    { name = "wrapt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/2c/cff26b706e1982317b19d1bd57bc7809fbbc586da794c968d1b3997e1b85/napari-0.6.5.tar.gz", hash = "sha256:00663221583467f41fa956a672b0b4cd7a761e2642db41fc3c336d1c82339533", size = 3249897, upload-time = "2025-10-02T02:18:48.616Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/69/1e8c5c7d487ad109206ce7f028ad02d41171641e1e95b4e45a913ee4d6b1/napari-0.6.5-py3-none-any.whl", hash = "sha256:51bc0b0fb6b6271555ad4167ce510b9453735aaad0ef947cfbc38bdd03d6a7be", size = 3536276, upload-time = "2025-10-02T02:18:46.062Z" },
-]
-
-[[package]]
-name = "napari-animation"
-version = "0.0.10"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "imageio" },
-    { name = "imageio-ffmpeg" },
-    { name = "napari" },
-    { name = "npe2" },
-    { name = "numpy" },
-    { name = "qtpy" },
-    { name = "scipy" },
-    { name = "superqt" },
-    { name = "tqdm" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/fe/c366a18b0e0195e4aef5e8d30abfaba0908a4b73d2787fdc79a7084de694/napari_animation-0.0.10.tar.gz", hash = "sha256:ce5970f50afd15bb81d7a296ba864c04b1747ce7323994563c3fff38ac318168", size = 820855, upload-time = "2026-04-13T19:36:22.398Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/75/d5881e1bcaec771c30a85293e9689191ac12999f0536639e8402c298c0d2/napari_animation-0.0.10-py3-none-any.whl", hash = "sha256:4caf663226b5b5759125dcaa8056080ab7022d67eb2b11ed84008ba11bedeca6", size = 36305, upload-time = "2026-04-13T19:36:20.476Z" },
-]
-
-[[package]]
-name = "napari-console"
-version = "0.1.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ipykernel" },
-    { name = "ipython" },
-    { name = "qtconsole" },
-    { name = "qtpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/41/4e/9b65e4c4e9520888fe69c6307818f4f75b0113b0fab1db67424b29bed9fe/napari_console-0.1.3.tar.gz", hash = "sha256:ba4f7e1cdca65a7924631372a5e58884e2e35a2b9092c79b98acb9c2dfe1254f", size = 20010, upload-time = "2024-12-20T13:48:58.451Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/ff/1d1aad9292aeccf01f94ca150ce621737cbe7b9fabbb0bfef32b8da70e58/napari_console-0.1.3-py3-none-any.whl", hash = "sha256:29d1700b85561b8c91331821360c9cd0e989350f4a06b86239ec65bc06c7aecb", size = 9990, upload-time = "2024-12-20T13:48:54.093Z" },
-]
-
-[[package]]
-name = "napari-ome-zarr"
-version = "0.8.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "napari" },
-    { name = "zarr" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/e1b69d9620473018e2f089376333539bd9fc5bd2c3ceabf3cb90b17478af/napari_ome_zarr-0.8.2.tar.gz", hash = "sha256:98a5441e73f01d56ad40e5d96f8f0c9cb21542882d2dc06e10846f6b036b17f2", size = 24925, upload-time = "2026-05-28T21:26:09.353Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/1c/3412c6ea4fef22473ab2734711b4c63a93ce5b2d507d1586ce58b301c9bb/napari_ome_zarr-0.8.2-py3-none-any.whl", hash = "sha256:46709e32fc6c37e5ec41e648355eb2a1f9d8dd41499afdfc566ca925c33c3fdf", size = 13598, upload-time = "2026-05-28T21:26:08.338Z" },
-]
-
-[[package]]
-name = "napari-plugin-engine"
-version = "0.2.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/72/c653308edaf7f7c84d82e388a1c46bc8f26c385027af58b5bf728f600b47/napari_plugin_engine-0.2.1.tar.gz", hash = "sha256:46829cf02f368c8f2f1aa8b998ec73bcf14a2c1f5c15abd94b82154d7aef510d", size = 55809, upload-time = "2026-02-10T08:31:20.385Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/bc/2509813cddd0e02736121e21bef54deeec7f0f89af2c6096d753ee1feb09/napari_plugin_engine-0.2.1-py3-none-any.whl", hash = "sha256:de30babe6fd9477816f037207938a2da7faeddc0e9e8663cb29f3d74235b6dc5", size = 33849, upload-time = "2026-02-10T08:31:19.037Z" },
-]
-
-[[package]]
-name = "napari-svg"
-version = "0.2.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "imageio" },
-    { name = "numpy" },
-    { name = "vispy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/90/802f8288d16c1513b908d644779e733461a53b6c1a2c7561f1464c9f1516/napari_svg-0.2.1.tar.gz", hash = "sha256:031f13b34b0948afbdcb11eb00728fe32ef7e4e3aa3905f923001d6871a08ad9", size = 17533, upload-time = "2025-01-14T07:26:30.657Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/ae/0eeb22806c4157a9199f65a93374e5ff5c4d2cc1411b5d25053bcd9e6b91/napari_svg-0.2.1-py3-none-any.whl", hash = "sha256:9eaa54fbbf9bfd5078b67b7d1edc9eccfd872dab89fd586374909fef4ed89a49", size = 16458, upload-time = "2025-01-14T07:26:29.328Z" },
-]
-
-[[package]]
 name = "narwhals"
 version = "2.22.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2156,31 +1441,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nbconvert"
-version = "7.17.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "beautifulsoup4" },
-    { name = "bleach", extra = ["css"] },
-    { name = "defusedxml" },
-    { name = "jinja2" },
-    { name = "jupyter-core" },
-    { name = "jupyterlab-pygments" },
-    { name = "markupsafe" },
-    { name = "mistune" },
-    { name = "nbclient" },
-    { name = "nbformat" },
-    { name = "packaging" },
-    { name = "pandocfilters" },
-    { name = "pygments" },
-    { name = "traitlets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/01/b1/708e53fe2e429c103c6e6e159106bcf0357ac41aa4c28772bd8402339051/nbconvert-7.17.1.tar.gz", hash = "sha256:34d0d0a7e73ce3cbab6c5aae8f4f468797280b01fd8bd2ca746da8569eddd7d2", size = 865311, upload-time = "2026-04-08T00:44:14.914Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/f8/bb0a9d5f46819c821dc1f004aa2cc29b1d91453297dbf5ff20470f00f193/nbconvert-7.17.1-py3-none-any.whl", hash = "sha256:aa85c087b435e7bf1ffd03319f658e285f2b89eccab33bc1ba7025495ab3e7c8", size = 261927, upload-time = "2026-04-08T00:44:12.845Z" },
-]
-
-[[package]]
 name = "nbformat"
 version = "5.10.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2211,38 +1471,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
-]
-
-[[package]]
-name = "notebook-shim"
-version = "0.2.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jupyter-server" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/54/d2/92fa3243712b9a3e8bafaf60aac366da1cada3639ca767ff4b5b3654ec28/notebook_shim-0.2.4.tar.gz", hash = "sha256:b4b2cfa1b65d98307ca24361f5b30fe785b53c3fd07b7a47e89acb5e6ac638cb", size = 13167, upload-time = "2024-02-14T23:35:18.353Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/33/bd5b9137445ea4b680023eb0469b2bb969d61303dedb2aac6560ff3d14a1/notebook_shim-0.2.4-py3-none-any.whl", hash = "sha256:411a5be4e9dc882a074ccbcae671eda64cceb068767e9a3419096986560e1cef", size = 13307, upload-time = "2024-02-14T23:35:16.286Z" },
-]
-
-[[package]]
-name = "npe2"
-version = "0.8.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "build" },
-    { name = "platformdirs" },
-    { name = "psygnal" },
-    { name = "pydantic" },
-    { name = "pydantic-extra-types" },
-    { name = "pyyaml" },
-    { name = "rich" },
-    { name = "tomli-w" },
-    { name = "typer" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/29/0a/1a6ed44b038484a064a0ac8e5f96aae6ddb8768789145cf7e65e699b324b/npe2-0.8.2.tar.gz", hash = "sha256:6e41cc1f2c873257d864980dd281b5bb649a84cef02feeb0cdda1a9d23fd8f8b", size = 122768, upload-time = "2026-04-04T20:55:11.9Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/a6/f318fbc7bbb62361d36cb694f399f765f57fb282fdadc3aa2fef4dafd62d/npe2-0.8.2-py3-none-any.whl", hash = "sha256:80eff5fef50352cf0f3407c4c1122a7ae186aede40a21fd595cf91988cd55a9d", size = 93921, upload-time = "2026-04-04T20:55:10.552Z" },
 ]
 
 [[package]]
@@ -2504,15 +1732,6 @@ wheels = [
 ]
 
 [[package]]
-name = "onemkl-license"
-version = "2026.0.0"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/fa/7c9af1e1fcea378257958355f7f2b80d6cc50a36ceebec0ad2fa9bd6b538/onemkl_license-2026.0.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:939058a4f34859863eaa3734b678e880cd1ce5f589458feea118bf2212514341", size = 58936, upload-time = "2026-04-24T14:13:19.607Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/8e/fc57a715c626333e2ac8d2444d97ae2b1421fe33628261645668e6b9624b/onemkl_license-2026.0.0-py2.py3-none-win_amd64.whl", hash = "sha256:8106d1177cc473b615e88d2051b4943aeb4c1408d79c8df22ab13ed8660760bb", size = 58961, upload-time = "2026-04-24T14:09:34.005Z" },
-]
-
-[[package]]
 name = "opencv-python-headless"
 version = "4.13.0.92"
 source = { registry = "https://pypi.org/simple" }
@@ -2573,15 +1792,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/21/ea191195e587b18cf682e97f433f81b2d0fbe341380e80a3e0d6e4403c8e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d26cbe1fcfc12e8fd900e2454163e466b2d3af84f7c75481df7683ffc073d870", size = 11350796, upload-time = "2026-05-11T18:53:32.056Z" },
     { url = "https://files.pythonhosted.org/packages/64/69/f0eaaf54939f0e8c6768fd06be9af2cef9b36048b96dfb9e1b2c685a807e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3e91cec1879ada0624fc3dc9953c5cbd60208e59c0db28f540c5d6d47502422f", size = 11799741, upload-time = "2026-05-11T18:53:34.985Z" },
     { url = "https://files.pythonhosted.org/packages/45/a4/865e0e510cae5fc2194de4db28be638952de942571ba9125934fd9c01d47/pandas-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:08d789b41f87e0905880e293cedf6197ce71fe67cc081358b1e148a491b9bd13", size = 10499958, upload-time = "2026-05-11T18:53:37.857Z" },
-]
-
-[[package]]
-name = "pandocfilters"
-version = "1.5.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/70/6f/3dd4940bbe001c06a65f88e36bad298bc7a0de5036115639926b0c5c0458/pandocfilters-1.5.1.tar.gz", hash = "sha256:002b4a555ee4ebc03f8b66307e287fa492e4a77b4ea14d3f934328297bb4939e", size = 8454, upload-time = "2024-01-18T20:08:13.726Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/af/4fbc8cab944db5d21b7e2a5b8e9211a03a79852b1157e2c102fcc61ac440/pandocfilters-1.5.1-py2.py3-none-any.whl", hash = "sha256:93be382804a9cdb0a7267585f157e5d1731bbe5545a85b268d6f5fe6232de2bc", size = 8663, upload-time = "2024-01-18T20:08:11.28Z" },
 ]
 
 [[package]]
@@ -2663,21 +1873,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pint"
-version = "0.25.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "flexcache" },
-    { name = "flexparser" },
-    { name = "platformdirs" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/52/9d/b1379cdbd33a49d17d627bc24e2b63cca06a1c5343b38072d2889499e82e/pint-0.25.3.tar.gz", hash = "sha256:f8f5df6cf65314d74da1ade1bf96f8e3e4d0c41b51577ac53c49e7d44ca5acee", size = 255106, upload-time = "2026-03-19T21:57:08.72Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl", hash = "sha256:27eb25143bd5de9fcc4d5a4b484f16faf6b4615aa93ece6b3373a8c1a3c1b97d", size = 307488, upload-time = "2026-03-19T21:57:07.022Z" },
-]
-
-[[package]]
 name = "platformdirs"
 version = "4.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2693,29 +1888,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
-]
-
-[[package]]
-name = "pooch"
-version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-    { name = "platformdirs" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/83/43/85ef45e8b36c6a48546af7b266592dc32d7f67837a6514d111bced6d7d75/pooch-1.9.0.tar.gz", hash = "sha256:de46729579b9857ffd3e741987a2f6d5e0e03219892c167c6578c0091fb511ed", size = 61788, upload-time = "2026-01-30T19:15:09.649Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/2d/d4bf65e47cea8ff2c794a600c4fd1273a7902f268757c531e0ee9f18aa58/pooch-1.9.0-py3-none-any.whl", hash = "sha256:f265597baa9f760d25ceb29d0beb8186c243d6607b0f60b83ecf14078dbc703b", size = 67175, upload-time = "2026-01-30T19:15:08.36Z" },
-]
-
-[[package]]
-name = "prometheus-client"
-version = "0.25.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
 ]
 
 [[package]]
@@ -2750,25 +1922,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
     { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
     { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
-]
-
-[[package]]
-name = "psygnal"
-version = "0.15.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4e/79/20c3e23e75272e9ddf018097cf872ab088bccba978888472656629efa4a3/psygnal-0.15.1.tar.gz", hash = "sha256:f64f62dee2306fc1c22050a59b6c6cdad126e04b0cf50e393ff858a1da719096", size = 123147, upload-time = "2026-01-04T16:38:41.959Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/65/b7bbca96bc477aa9ac2264e5907b2f4ccfcd1319f776dd1f35eec06cc2f4/psygnal-0.15.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8d56f0f35eaf4a21f660de76885222faf9e8c7112454528d3394d464f3d4d1a3", size = 598340, upload-time = "2026-01-04T16:38:19.752Z" },
-    { url = "https://files.pythonhosted.org/packages/40/f2/56577465a1b42a5e6780bb5fab53fb68f8bfd72f0131ed397576529af724/psygnal-0.15.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0febcf757a1323d9b8bd75735ee3569213d8110012a7bf0f478e85c5ab459fc6", size = 575311, upload-time = "2026-01-04T16:38:21.137Z" },
-    { url = "https://files.pythonhosted.org/packages/79/81/f642ac08104049383076f83480ed412c9626e068769a1c34873c595bec0e/psygnal-0.15.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b5e4837dfbfa4974dabe0795e32be9aadcd87603adf734738ce1114f72238a05", size = 889770, upload-time = "2026-01-04T16:38:22.629Z" },
-    { url = "https://files.pythonhosted.org/packages/de/43/e571fa40b72780abed080ef829e5ad98017b6fe48d28c15a2404e006b676/psygnal-0.15.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:07b4c4e03bbf4e8cad7e25f4fbc1ba9575fb9c3d14991bc7edfeb8b09c8d6d54", size = 881105, upload-time = "2026-01-04T16:38:23.896Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/26/ef3ab825eb08eaecbbceeeb56383694fe64ce399dbfd1d0767bb85688785/psygnal-0.15.1-cp312-cp312-win_amd64.whl", hash = "sha256:4f0ce91b9c18e92281bf2c3fc4bb4e808d90f0b023d0a37b302d354188520338", size = 418969, upload-time = "2026-01-04T16:38:25.731Z" },
-    { url = "https://files.pythonhosted.org/packages/46/21/5a142165d27063abf5921807d3c3d973f5d44ab414a13b210839a43ead4d/psygnal-0.15.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2087aadc9404f007f79c2899e329932869e362c50de58b90631c5f49b4768cc5", size = 596768, upload-time = "2026-01-04T16:38:27.053Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/25/c1712931d61c118691e73daf29ef708c679ea9ba187c797dd5deee360411/psygnal-0.15.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0f3bf68ca42569dfdce20c6cf915d34b78b9e3ddddacb9f78728224fda6946b4", size = 574808, upload-time = "2026-01-04T16:38:28.779Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/4f/3593e5adb88a188c798604aed95fbc1479f30230e7f51e8f2c770e6a3832/psygnal-0.15.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e9fca977f5335deea39aed22e31d9795983e4f243e59a7d3c4105793adb7693d", size = 885616, upload-time = "2026-01-04T16:38:30.081Z" },
-    { url = "https://files.pythonhosted.org/packages/58/4c/14779ed4c3a1d71fa1a9a87ecfb184ad3335dd64681067f77c1c47b14ae9/psygnal-0.15.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0c85b7d05b92ccbec47c75ab8a5545eda462e81a492c82424aba5ab81a3ad89d", size = 876516, upload-time = "2026-01-04T16:38:31.422Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/bc/4f771e3cdcde4db4023dbf36d6f0aab44e02b9de719353c22954b655e2ff/psygnal-0.15.1-cp313-cp313-win_amd64.whl", hash = "sha256:ac0e693b29e0a429e97315a52313321855bef6140e9975b7ae78b4d93c8fbb42", size = 419172, upload-time = "2026-01-04T16:38:32.82Z" },
-    { url = "https://files.pythonhosted.org/packages/46/49/7742544684bee728ec123515d2694cee859aa2a705951a461230b00f18cc/psygnal-0.15.1-py3-none-any.whl", hash = "sha256:4221140e633e45b076953c64bcb9b41a744833527f9a037c1ca98bc270798cbf", size = 90638, upload-time = "2026-01-04T16:38:40.841Z" },
 ]
 
 [[package]]
@@ -2816,109 +1969,12 @@ wheels = [
 ]
 
 [[package]]
-name = "pyconify"
-version = "0.2.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/7f/94d424dc756a6287271cf40cf1b2a44c10e3f137bf3246a2b4a7416ca3d3/pyconify-0.2.1.tar.gz", hash = "sha256:8dd53757d9fbed41711434460932b2b5dbc25da720cd9f9a44af0187b2dfc07d", size = 22478, upload-time = "2025-02-06T13:20:53.592Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/40/50dd2e8bfec81676e4619903bd452c10dc0d8efac1533e79e67cc76759b5/pyconify-0.2.1-py3-none-any.whl", hash = "sha256:d3b53eee1f8a2d60c1d135610f42e789774dbe71c6d8af68af0a21d3b3ec9eb7", size = 19459, upload-time = "2025-02-06T13:20:51.613Z" },
-]
-
-[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
-]
-
-[[package]]
-name = "pydantic"
-version = "2.13.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "annotated-types" },
-    { name = "pydantic-core" },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
-]
-
-[[package]]
-name = "pydantic-compat"
-version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/7e/43400b6e0800065a982efcfa3e87c8f8d247d60ea75ca1a9d01702e050f8/pydantic_compat-0.1.2.tar.gz", hash = "sha256:c5c5bca39ca2d22cad00c02898e400e1920e5127649a8e860637f15566739373", size = 12838, upload-time = "2023-10-24T23:25:09.544Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/65/2edf586ff7b3dfc520977c6529c9b718c86ef8459ece088f1ef1f74bf1d4/pydantic_compat-0.1.2-py3-none-any.whl", hash = "sha256:37a4df48565a35aedc947f0fde5edbdff270a30836d995923287292bb59d5677", size = 13092, upload-time = "2023-10-24T23:25:08.155Z" },
-]
-
-[[package]]
-name = "pydantic-core"
-version = "2.46.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
-    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
-    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
-    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
-    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
-    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
-    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
-    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
-    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
-    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
-    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
-    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
-    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
-]
-
-[[package]]
-name = "pydantic-extra-types"
-version = "2.11.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/66/71/dba38ee2651f84f7842206adbd2233d8bbdb59fb85e9fa14232486a8c471/pydantic_extra_types-2.11.1.tar.gz", hash = "sha256:46792d2307383859e923d8fcefa82108b1a141f8a9c0198982b3832ab5ef1049", size = 172002, upload-time = "2026-03-16T08:08:03.92Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl", hash = "sha256:1722ea2bddae5628ace25f2aa685b69978ef533123e5638cfbddb999e0100ec1", size = 79526, upload-time = "2026-03-16T08:08:02.533Z" },
 ]
 
 [[package]]
@@ -2980,15 +2036,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyopengl"
-version = "3.1.10"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/16/912b7225d56284859cd9a672827f18be43f8012f8b7b932bc4bd959a298e/pyopengl-3.1.10.tar.gz", hash = "sha256:c4a02d6866b54eb119c8e9b3fb04fa835a95ab802dd96607ab4cdb0012df8335", size = 1915580, upload-time = "2025-08-18T02:33:01.76Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/e4/1ba6f44e491c4eece978685230dde56b14d51a0365bc1b774ddaa94d14cd/pyopengl-3.1.10-py3-none-any.whl", hash = "sha256:794a943daced39300879e4e47bd94525280685f42dbb5a998d336cfff151d74f", size = 3194996, upload-time = "2025-08-18T02:32:59.902Z" },
-]
-
-[[package]]
 name = "pyparsing"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2998,29 +2045,17 @@ wheels = [
 ]
 
 [[package]]
-name = "pyproject-hooks"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
-]
-
-[[package]]
 name = "pyqt6"
 version = "6.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyqt6-qt6" },
-    { name = "pyqt6-sip" },
+    { name = "pyqt6-qt6", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pyqt6-sip", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8b/47/b25c13eca5bebc6505394d0223e46d7ebf0c57dcac2ed908d7d19b18ab6b/pyqt6-6.11.0.tar.gz", hash = "sha256:45dd60aa69976de1918b5ced6b4e7b6a25abd2a919ecef5fd5826ecc76718889", size = 1087430, upload-time = "2026-03-30T09:16:13.543Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/44/fcd3dd3f64c83c96bf9bce76ec16cca64bd9b91702c3d08fd8e3dafc73d9/pyqt6-6.11.0-cp310-abi3-macosx_10_14_universal2.whl", hash = "sha256:f7100bc7f72b12581ec479a733f4ad11b8002668e6786e8a445ab6f4d1c743d4", size = 12429735, upload-time = "2026-03-30T09:16:03.713Z" },
     { url = "https://files.pythonhosted.org/packages/c3/a0/bd1399740dfa80c0a94d20b02d89962a31458233dcf70eaa09bfbccf3d0f/pyqt6-6.11.0-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:8555277989fa7d114cb3c3443fd261d566909f7268ceedd41d93a5f02d37ec05", size = 8334632, upload-time = "2026-03-30T09:16:06.066Z" },
     { url = "https://files.pythonhosted.org/packages/d3/db/425b184ac2430ba1978bb507ffd285ec007a872644e2ae5df13332dbcb05/pyqt6-6.11.0-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:0734959955adde095af9a074213a7f73386d1bbbddfc27346b4c0621641a692e", size = 8321484, upload-time = "2026-03-30T09:16:08.135Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/85/dd9f03d78d87460e109e0121cd6201c5802bdd655656bf2780e964870fea/pyqt6-6.11.0-cp310-abi3-win_amd64.whl", hash = "sha256:bd11b459c54dca068e988a42cf838303334f0d441b9d16d92ae6719fcb5ac6ba", size = 6844358, upload-time = "2026-03-30T09:16:09.766Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/75/970b041bde4372cc6739c5ef9db1de83a6b36e788e4992e598baa35b2255/pyqt6-6.11.0-cp310-abi3-win_arm64.whl", hash = "sha256:b6324e3501b19b4292c7a55b1f22e82d3e80e519e383ce4fe79b4a754c6f0288", size = 5933984, upload-time = "2026-03-30T09:16:11.817Z" },
 ]
 
 [[package]]
@@ -3028,12 +2063,8 @@ name = "pyqt6-qt6"
 version = "6.11.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/cb/ef930289bcd3b4be77a619d6b89ccdd0f53d753053a45f69ed590fd49777/pyqt6_qt6-6.11.1-py3-none-macosx_10_14_x86_64.whl", hash = "sha256:694486f18b7ab9b1edcdb50e0c9f5cb726e096107da90ae7b0e810f18e2002b3", size = 70402836, upload-time = "2026-05-15T11:18:24.893Z" },
-    { url = "https://files.pythonhosted.org/packages/09/7d/d016af2de1975a0d90c9a911e3d82b2e8c8fe899f8af746ade42186f3845/pyqt6_qt6-6.11.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fd05b31a3c83111b6eb82bb472ccfe531ef823f70d085b82fd1edc5ad2553c54", size = 64167714, upload-time = "2026-05-15T11:18:48.848Z" },
     { url = "https://files.pythonhosted.org/packages/e1/be/21d0df9bde717131f4245f8801676120d466afe198c4641c9e4982cf85fe/pyqt6_qt6-6.11.1-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:254af349e0ef4b2fa581f86ee9d65eb797bb1d4f0c01ae5ceaa7b2446b458be9", size = 85897589, upload-time = "2026-05-15T11:19:21.864Z" },
     { url = "https://files.pythonhosted.org/packages/08/69/f6b9cafceed9790c62a7ca3044562d38545bbfcfaf222846482ac2f9bd56/pyqt6_qt6-6.11.1-py3-none-manylinux_2_39_aarch64.whl", hash = "sha256:039b1ab619d63d06a87cacf84b581a2b61a30c9ad5bb677553e738afe4dc433a", size = 84996419, upload-time = "2026-05-15T11:19:52.647Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/f1/70e83c23bf897c7f5025aa100482f482038ef70232dc27b407659d941fbf/pyqt6_qt6-6.11.1-py3-none-win_amd64.whl", hash = "sha256:7486c80512e823f2d3087e67f854f0556b345f4368040a853c8dc4d30fd3fe69", size = 78416766, upload-time = "2026-05-15T11:20:20.588Z" },
-    { url = "https://files.pythonhosted.org/packages/93/b0/9183ec9c206a0c3cba5719f0911e88a3486167137456a0f9318f07ce000d/pyqt6_qt6-6.11.1-py3-none-win_arm64.whl", hash = "sha256:120efbedf833e5bbbc3d64ebdb139b44ff34e60f34410c7b1c2c26d230380bda", size = 59961004, upload-time = "2026-05-15T11:20:49.065Z" },
 ]
 
 [[package]]
@@ -3042,28 +2073,10 @@ version = "13.11.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/90/24/a753e1af94b9ae5b2da63d4598457308da3cdbf0838c959381db086ccc86/pyqt6_sip-13.11.1.tar.gz", hash = "sha256:869c5b48afe38e55b1ee0dd72182b0886e968cc509b98023ff50010b013ce1be", size = 92574, upload-time = "2026-03-09T13:01:35.418Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/27/47598e701d284497216bf97bf8b6a69f5e61412e716c232ff2b7e6cb2100/pyqt6_sip-13.11.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:ba9d362dd1e54b43bc2594f8841e1e39d24789716d28f08e5c9282af9fca342c", size = 112564, upload-time = "2026-03-09T13:01:14.628Z" },
     { url = "https://files.pythonhosted.org/packages/95/cb/116f9b328636765f3bce97d9e10ec041c54bbe92beb0617edb86c2b615c1/pyqt6_sip-13.11.1-cp312-cp312-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0df15849946cea969d3ff2b24b76149262b6044aea2c5403e4f70c24c973a4c8", size = 299564, upload-time = "2026-03-09T13:01:17.292Z" },
     { url = "https://files.pythonhosted.org/packages/1b/be/fe2321285e8f683e705d199dbb458131f1850dc5966155a19c40100c85bb/pyqt6_sip-13.11.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c52b2b27fc77d9447a8dc1c6de1aaccc22d41e48697aafb2f2f20b8984bb02a5", size = 321210, upload-time = "2026-03-09T13:01:15.904Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/9b/7d4b10f9cba1b6f581dfb4860b9d11898da55a5ed3b8a6e7a1bf9f7084d0/pyqt6_sip-13.11.1-cp312-cp312-win_amd64.whl", hash = "sha256:1d1c67179c1924b28e3d7f04585639e7a7c0946f62390efc6ccf2a6206e595d3", size = 53351, upload-time = "2026-03-09T13:01:19.327Z" },
-    { url = "https://files.pythonhosted.org/packages/06/72/6c4e6f21cafa4bed40d2b0c1563525b0d8bfcb5734493696f4cfd043b45f/pyqt6_sip-13.11.1-cp312-cp312-win_arm64.whl", hash = "sha256:d83543125fe9fdb153e7e446c3b4d056d80ab5953644660633ab3f80e7784194", size = 48746, upload-time = "2026-03-09T13:01:20.248Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/0b/dc76c463c203e630b2c6417d4d5e337e919a265ac1c10127ef413551f5de/pyqt6_sip-13.11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:0c6d097aae7df312519e2b36e001bd796f6a2ce060ab8b9ed793daa8f407fe2e", size = 112552, upload-time = "2026-03-09T13:01:21.493Z" },
     { url = "https://files.pythonhosted.org/packages/d4/e3/65b605759859d38231ce7544065d4c61f891eb7766c351318e2a0b08a473/pyqt6_sip-13.11.1-cp313-cp313-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a72f4ebdab16a8a484019ff593de90d8013d3286b678c6ba1c0bdb117f4fcb13", size = 299932, upload-time = "2026-03-09T13:01:24.912Z" },
     { url = "https://files.pythonhosted.org/packages/60/f7/c10d2dd5bf503a1de83bd163467bd323f12af016866c2814743b5b1efe1c/pyqt6_sip-13.11.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b68e442efc4275651bf63f2c43713e242924fd948909e31cf8f20d783ca505e9", size = 321497, upload-time = "2026-03-09T13:01:22.724Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/1f/e7e5ad77a76c00db5c8c1b9960f2b0672ec1978b971bb3509858cd7a9458/pyqt6_sip-13.11.1-cp313-cp313-win_amd64.whl", hash = "sha256:ca24bfd4d5d8274e338433df9ac41930650088c00018d3313c6bd8de21772a02", size = 53371, upload-time = "2026-03-09T13:01:26.286Z" },
-    { url = "https://files.pythonhosted.org/packages/36/ef/a7acaf44980aed6fe26f1320e265db528fecb6a47ac67829c7cd011e9821/pyqt6_sip-13.11.1-cp313-cp313-win_arm64.whl", hash = "sha256:f532144c43f2fddcccf2e25df50cdb4a744edb4ce4ba5ed2d0f2cef825197f2f", size = 48745, upload-time = "2026-03-09T13:01:27.212Z" },
-]
-
-[[package]]
-name = "pyqtgraph"
-version = "0.14.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama" },
-    { name = "numpy" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/36/4c242f81fdcbfa4fb62a5645f6af79191f4097a0577bd5460c24f19cc4ef/pyqtgraph-0.14.0-py3-none-any.whl", hash = "sha256:7abb7c3e17362add64f8711b474dffac5e7b0e9245abdf992e9a44119b7aa4f5", size = 1924755, upload-time = "2025-11-16T19:43:22.251Z" },
 ]
 
 [[package]]
@@ -3092,42 +2105,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
-]
-
-[[package]]
-name = "python-json-logger"
-version = "4.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f7/ff/3cc9165fd44106973cd7ac9facb674a65ed853494592541d339bdc9a30eb/python_json_logger-4.1.0.tar.gz", hash = "sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195", size = 17573, upload-time = "2026-03-29T04:39:56.805Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl", hash = "sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2", size = 15021, upload-time = "2026-03-29T04:39:55.266Z" },
-]
-
-[[package]]
-name = "pywin32"
-version = "312"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
-    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
-    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
-]
-
-[[package]]
-name = "pywinpty"
-version = "3.0.5"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a9/ef/2d27f30c59a67be7025b2d7858c8c2d282b74d66544b2384730b82de74fd/pywinpty-3.0.5.tar.gz", hash = "sha256:61db0db063de9865adbea66db294628f8577f608d9764a4c7d3384eeacc4e81b", size = 16223484, upload-time = "2026-06-11T00:11:58.93Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/34/942cc95ca4e26489875aa8a95192766247a687379ec29543eebe73ec945f/pywinpty-3.0.5-cp312-cp312-win_amd64.whl", hash = "sha256:d62946adf14b15b54c0b8d785f93fe18b04da23f4ad59e2e8c4612646e9abd23", size = 2090915, upload-time = "2026-06-10T23:43:14.98Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/70/5b9053004844139ea8bd86209c57ade12b134b2782f383a095784c8531ec/pywinpty-3.0.5-cp312-cp312-win_arm64.whl", hash = "sha256:e9391c05fbfa7a992a97e831fc6849887b4014a614192e3d984a7ca59592b376", size = 815934, upload-time = "2026-06-10T23:41:42.384Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/f4/2a464b9893cceb3b3f416356e94fdc3e1bca9476993927e4e6d99fe95382/pywinpty-3.0.5-cp313-cp313-win_amd64.whl", hash = "sha256:48db1b0ad9d0a1b81dcaaa7163a99a7808deaceb0c1b2344716dc1fc090c3c4c", size = 2090471, upload-time = "2026-06-10T23:42:11.071Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/2c/a138491a0afbdb50eb79395577bd326d4b0fbde7209417d1a8087ff2493a/pywinpty-3.0.5-cp313-cp313-win_arm64.whl", hash = "sha256:2c6008fb2d3774b48693b2fcb7f2cc317ade9dc581289a964ffeeaf81307c9b5", size = 815518, upload-time = "2026-06-10T23:42:02.363Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/15/54400049a380582acd1282665c70fcf11e0bd3713679aca78e24c3aae738/pywinpty-3.0.5-cp313-cp313t-win_amd64.whl", hash = "sha256:22ce1b780d89821cc52daf6eac0708af22d93d000ce9c7c07e37489db8594598", size = 2089920, upload-time = "2026-06-10T23:44:13.395Z" },
-    { url = "https://files.pythonhosted.org/packages/94/0c/6f24f3c0799f502259b24bdf841a99ad2b0d59df5c2525b4e2a286d14be2/pywinpty-3.0.5-cp313-cp313t-win_arm64.whl", hash = "sha256:9c2919a81bc5cfb09b86fc5a002112b2de95ca4304a07413cbeeb746a1307a5c", size = 814520, upload-time = "2026-06-10T23:43:28.588Z" },
 ]
 
 [[package]]
@@ -3192,37 +2169,6 @@ wheels = [
 ]
 
 [[package]]
-name = "qtconsole"
-version = "5.7.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ipykernel" },
-    { name = "ipython-pygments-lexers" },
-    { name = "jupyter-client" },
-    { name = "jupyter-core" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "qtpy" },
-    { name = "traitlets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/28/4070eb0bacb99bc00bf60173fda25fb6a559d6600040035ba96c196d3647/qtconsole-5.7.2.tar.gz", hash = "sha256:27b485b9161925924c1d8e78e66bb342e6e3bc49bf675d0a67b49bad9c291521", size = 436661, upload-time = "2026-03-25T02:24:38.895Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/60/aba9f3c3f1f48c7fbdf03bed45b576a916cd09c08242939b5294b85e37b4/qtconsole-5.7.2-py3-none-any.whl", hash = "sha256:e1d1f6a792123363626e643a7a4ee561217773571043992693fba7eccfa89f95", size = 125883, upload-time = "2026-03-25T02:24:36.95Z" },
-]
-
-[[package]]
-name = "qtpy"
-version = "2.4.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/70/01/392eba83c8e47b946b929d7c46e0f04b35e9671f8bb6fc36b6f7945b4de8/qtpy-2.4.3.tar.gz", hash = "sha256:db744f7832e6d3da90568ba6ccbca3ee2b3b4a890c3d6fbbc63142f6e4cdf5bb", size = 66982, upload-time = "2025-02-11T15:09:25.759Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/76/37c0ccd5ab968a6a438f9c623aeecc84c202ab2fabc6a8fd927580c15b5a/QtPy-2.4.3-py3-none-any.whl", hash = "sha256:72095afe13673e017946cc258b8d5da43314197b741ed2890e563cf384b51aa1", size = 95045, upload-time = "2025-02-11T15:09:24.162Z" },
-]
-
-[[package]]
 name = "rastermap"
 version = "1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3278,52 +2224,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
-]
-
-[[package]]
-name = "rfc3339-validator"
-version = "0.1.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/28/ea/a9387748e2d111c3c2b275ba970b735e04e15cdb1eb30693b6b5708c4dbd/rfc3339_validator-0.1.4.tar.gz", hash = "sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b", size = 5513, upload-time = "2021-05-12T16:37:54.178Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl", hash = "sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa", size = 3490, upload-time = "2021-05-12T16:37:52.536Z" },
-]
-
-[[package]]
-name = "rfc3986-validator"
-version = "0.1.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/da/88/f270de456dd7d11dcc808abfa291ecdd3f45ff44e3b549ffa01b126464d0/rfc3986_validator-0.1.1.tar.gz", hash = "sha256:3d44bde7921b3b9ec3ae4e3adca370438eccebc676456449b145d533b240d055", size = 6760, upload-time = "2019-10-28T16:00:19.144Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/51/17023c0f8f1869d8806b979a2bffa3f861f26a3f1a66b094288323fba52f/rfc3986_validator-0.1.1-py2.py3-none-any.whl", hash = "sha256:2f235c432ef459970b4306369336b9d5dbdda31b510ca1e327636e01f528bfa9", size = 4242, upload-time = "2019-10-28T16:00:13.976Z" },
-]
-
-[[package]]
-name = "rfc3987-syntax"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "lark" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/06/37c1a5557acf449e8e406a830a05bf885ac47d33270aec454ef78675008d/rfc3987_syntax-1.1.0.tar.gz", hash = "sha256:717a62cbf33cffdd16dfa3a497d81ce48a660ea691b1ddd7be710c22f00b4a0d", size = 14239, upload-time = "2025-07-18T01:05:05.015Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/71/44ce230e1b7fadd372515a97e32a83011f906ddded8d03e3c6aafbdedbb7/rfc3987_syntax-1.1.0-py3-none-any.whl", hash = "sha256:6c3d97604e4c5ce9f714898e05401a0445a641cfa276432b0a648c80856f6a3f", size = 8046, upload-time = "2025-07-18T01:05:03.843Z" },
-]
-
-[[package]]
-name = "rich"
-version = "15.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markdown-it-py" },
-    { name = "pygments" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
 ]
 
 [[package]]
@@ -3468,11 +2368,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/ba/73b6ca70796e71f83ab222690e35a79612f0117e5aaf167151b7d46f5f2c/scikit_image-0.26.0-cp313-cp313t-win_arm64.whl", hash = "sha256:27d58bc8b2acd351f972c6508c1b557cfed80299826080a4d803dd29c51b707e", size = 11647755, upload-time = "2025-12-20T17:11:45.279Z" },
 ]
 
-[package.optional-dependencies]
-data = [
-    { name = "pooch" },
-]
-
 [[package]]
 name = "scikit-learn"
 version = "1.9.0"
@@ -3532,20 +2427,6 @@ wheels = [
 ]
 
 [[package]]
-name = "seaborn"
-version = "0.13.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "matplotlib" },
-    { name = "numpy" },
-    { name = "pandas" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/86/59/a451d7420a77ab0b98f7affa3a1d78a313d2f7281a57afb1a34bae8ab412/seaborn-0.13.2.tar.gz", hash = "sha256:93e60a40988f4d65e9f4885df477e2fdaff6b73a9ded434c1ab356dd57eefff7", size = 1457696, upload-time = "2024-01-25T13:21:52.551Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl", hash = "sha256:636f8336facf092165e27924f223d3c62ca560b1f2bb5dff7ab7fad265361987", size = 294914, upload-time = "2024-01-25T13:21:49.598Z" },
-]
-
-[[package]]
 name = "segment-anything"
 version = "1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3555,53 +2436,12 @@ wheels = [
 ]
 
 [[package]]
-name = "send2trash"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c5/f0/184b4b5f8d00f2a92cf96eec8967a3d550b52cf94362dad1100df9e48d57/send2trash-2.1.0.tar.gz", hash = "sha256:1c72b39f09457db3c05ce1d19158c2cbef4c32b8bedd02c155e49282b7ea7459", size = 17255, upload-time = "2026-01-14T06:27:36.056Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/78/504fdd027da3b84ff1aecd9f6957e65f35134534ccc6da8628eb71e76d3f/send2trash-2.1.0-py3-none-any.whl", hash = "sha256:0da2f112e6d6bb22de6aa6daa7e144831a4febf2a87261451c4ad849fe9a873c", size = 17610, upload-time = "2026-01-14T06:27:35.218Z" },
-]
-
-[[package]]
 name = "setuptools"
 version = "80.10.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/76/95/faf61eb8363f26aa7e1d762267a8d602a1b26d4f3a1e758e92cb3cb8b054/setuptools-80.10.2.tar.gz", hash = "sha256:8b0e9d10c784bf7d262c4e5ec5d4ec94127ce206e8738f29a437945fbc219b70", size = 1200343, upload-time = "2026-01-25T22:38:17.252Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/b8/f1f62a5e3c0ad2ff1d189590bfa4c46b4f3b6e49cef6f26c6ee4e575394d/setuptools-80.10.2-py3-none-any.whl", hash = "sha256:95b30ddfb717250edb492926c92b5221f7ef3fbcc2b07579bcd4a27da21d0173", size = 1064234, upload-time = "2026-01-25T22:38:15.216Z" },
-]
-
-[[package]]
-name = "shellingham"
-version = "1.5.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
-]
-
-[[package]]
-name = "simplejpeg"
-version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/90/64/da60f0ba80570f9a36c9b6e055f4364bda2c547715296d5773d2ea6d5a60/simplejpeg-1.9.0.tar.gz", hash = "sha256:5ac7d9489eeb812c2e7ea5c283994a29d9fefdfe5ed7b86c09d485e0dd366689", size = 3965764, upload-time = "2025-10-10T10:58:08.197Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/05/a932dc6a89cdfd8cdfbd300340d87164eb3daaaf6a1b86b09bf0b87e0c2a/simplejpeg-1.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f218b4810f0dcb573bf323dae73177961c235c79588657927d7893a714636ca2", size = 424657, upload-time = "2025-10-10T10:57:36.676Z" },
-    { url = "https://files.pythonhosted.org/packages/44/73/53f7d2e0ce86c9b850301c1c9165dedbac9ac88a6045aa1cb8ad37176c17/simplejpeg-1.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f987b5783e0d649457acf136a4544a75f6d40f15cba89b6c5a4583ccf5577957", size = 401461, upload-time = "2025-10-10T10:57:37.963Z" },
-    { url = "https://files.pythonhosted.org/packages/75/c1/0cbf167e3efa32adfbb0674a3504eb118cc5bdc372a44ee937c30324188e/simplejpeg-1.9.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:08ab337ca3b26d7562f5ad686ab8f3966fb206fced607d248e693cbc57fc53b3", size = 448908, upload-time = "2025-10-10T10:57:39.303Z" },
-    { url = "https://files.pythonhosted.org/packages/03/80/44514f83a09500d1eb8ebba8cadd9aa16f7a60690c19dbd98a570ca2c0ec/simplejpeg-1.9.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5be1c8932f43f99b6cc52f8ac4c28e3ac19a1a830351efdb159715fd683e2053", size = 407547, upload-time = "2025-10-10T10:57:40.867Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/d7/115be2e87257c1e148c0f911c020c6442eafb8d164cbd642327d21f22179/simplejpeg-1.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:808b6840f1c6d4de20ae7a086cf9bf49eccac6ef6658df34b4948e071cbe9680", size = 293810, upload-time = "2025-10-10T10:57:42.498Z" },
-    { url = "https://files.pythonhosted.org/packages/49/21/6a4c1589fbcde51a349ef7a629af5867701011bced774389a4f6782ef6cd/simplejpeg-1.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:b65fdde80097cb1fad9c6dad6a12767215c311704f7fad321fbd8501219fad06", size = 253182, upload-time = "2025-10-10T10:57:44.051Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/32/c2d5baa4af82551feae9082d1800c7c7e96586f67292dad4e1442298ad34/simplejpeg-1.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52b4e8e0d68caa3e0962415daff12df2911df36a697e53a75878a45e9e34e9ad", size = 423518, upload-time = "2025-10-10T10:57:45.291Z" },
-    { url = "https://files.pythonhosted.org/packages/84/97/6a4018d4c1c980d9f4c48c29d3d6bfaeb18444dd8e82997246c9950fb79a/simplejpeg-1.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:475d1932f50264d63dbc752678b5a6629ed8c6b0f5edfbe4e9cd7881d5f8a1f1", size = 400574, upload-time = "2025-10-10T10:57:46.475Z" },
-    { url = "https://files.pythonhosted.org/packages/88/8b/d8ca384f1362371d61690d7460d3ae4cec4a5a25d9eb06cd15623de3725a/simplejpeg-1.9.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a0c375130f73bb08229a3ded392d84ee2d916b3e87e7ec5d2ac4e47b7144346a", size = 448142, upload-time = "2025-10-10T10:57:47.894Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/0a/58d6d8e997ee01486cfcfd4406a74638f2f63bb65122694b10411dadf1d5/simplejpeg-1.9.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d00feb1cc0348aba0a41db6dbda4db468db92099b1b3d473159e6f68aa990795", size = 406252, upload-time = "2025-10-10T10:57:49.158Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/12/c95aef82037bd2082e9a35b949352e9d8477afec540fefe48c7502114bca/simplejpeg-1.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:7b58f81133040ff7103dee90bb4f949e34456084f86347fb388505f3a0a42895", size = 293831, upload-time = "2025-10-10T10:57:50.576Z" },
-    { url = "https://files.pythonhosted.org/packages/84/cd/41e96d4b82a20d2d448a55a21831c1e57c920f7da485850717da7cf5036a/simplejpeg-1.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:acf6acd6c41a4a42fd9d89cf4d3f3d6a072d0eb5dbc231c1620e165f79a8cad5", size = 253131, upload-time = "2025-10-10T10:57:51.754Z" },
 ]
 
 [[package]]
@@ -3883,6 +2723,19 @@ wheels = [
 ]
 
 [[package]]
+name = "submitit"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/86/497018fb3b74e71bef45df82762b176e6b3d159f29941c20d2f141ec4096/submitit-1.5.4.tar.gz", hash = "sha256:7100848bd1cdda79c7196e54ee830793ae75fd7adde0c5bef738d72360a07508", size = 81538, upload-time = "2025-12-17T19:20:03.396Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/bb/711e1c2ebd18a21202c972dd5d5c8e09a921f2d3560e3a53d6350c808ab7/submitit-1.5.4-py3-none-any.whl", hash = "sha256:c26f3a7c8d4150eaf70b1da71e2023e9e9936c93e8342ed7db910f29158561c5", size = 76043, upload-time = "2025-12-17T19:20:01.941Z" },
+]
+
+[[package]]
 name = "suite2p"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3902,25 +2755,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/48/27/1031be9357bbea04db27195e7f9846fc895e9e9def6550d2fe52d69b0b72/suite2p-1.1.0.tar.gz", hash = "sha256:82d53175bfd4686462c18f183d5206cb6eefc8b214de03aa249b00f1c7c2d9bb", size = 9709772, upload-time = "2026-06-02T16:52:09.445Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a1/48/7f8c84641b74a62a36211a26ac6272d0f965a3198eb6db294d0bfd80a27c/suite2p-1.1.0-py3-none-any.whl", hash = "sha256:8a231a5f78d0190c3db68b1f1d7ed8efb72facc8513154e7e1346afc601d77d1", size = 686261, upload-time = "2026-06-02T16:52:07.846Z" },
-]
-
-[[package]]
-name = "superqt"
-version = "0.8.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pygments" },
-    { name = "qtpy" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/84/fe/919245507b15b4633cd40292d69c3b6afa8a650bf3ec33f3329d26314a3c/superqt-0.8.2.tar.gz", hash = "sha256:faa3bd00ef1c9b209b1f31b154dd41c596fec3824f61a70c251fb5569acd7ba6", size = 110190, upload-time = "2026-05-18T14:33:47.027Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/b9/748c3cbcdba20ef01c055a35905cad5c771cc1df29be11b9a82da6fd8e0d/superqt-0.8.2-py3-none-any.whl", hash = "sha256:ce8400ae7b577d090368aae5bdbabb06cd6bc893f6ca73485bb686835bf20943", size = 101595, upload-time = "2026-05-18T14:33:45.462Z" },
-]
-
-[package.optional-dependencies]
-iconify = [
-    { name = "pyconify" },
 ]
 
 [[package]]
@@ -3945,41 +2779,6 @@ wheels = [
 ]
 
 [[package]]
-name = "tbb"
-version = "2023.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "tcmlib" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/d2/9a994ce9b18182b04783282eba77e236d23919acf42a886d72fe14fc78a4/tbb-2023.0.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:482f57656386ea14b96e8da36b3fcc4cd880834ef0f328ba09e8e2e3c639285e", size = 6785156, upload-time = "2026-04-24T14:10:01.59Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/f8/dd5e1d9955c91ebd301d855232163750489b20ea5a8c4e40954269493dcc/tbb-2023.0.0-py3-none-win_amd64.whl", hash = "sha256:82d1c2b4b6881d5b4f2e67288ca1c864f54e3cd82c7e428aaf912aa30ab21d01", size = 427718, upload-time = "2026-04-24T14:10:47.885Z" },
-]
-
-[[package]]
-name = "tcmlib"
-version = "1.5.0"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/24/aa409bb20703acc70cf4d3bc620a55c789639c2995b2667fb44ae7236ec9/tcmlib-1.5.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:9d7c01cff35aae9bf5390b620680ebdf10a7d211c22d6488a27a029502e7d0aa", size = 2812669, upload-time = "2026-04-24T14:14:18.557Z" },
-    { url = "https://files.pythonhosted.org/packages/67/6d/9095c93326d0f8a5469ab22480d02795f24c08f1e7f383c73316ff106347/tcmlib-1.5.0-py2.py3-none-win_amd64.whl", hash = "sha256:f7b62787214083d490b39d7650f1e477eeacc875e7f86799feb9aa1fd34460d4", size = 366719, upload-time = "2026-04-24T14:09:45.977Z" },
-]
-
-[[package]]
-name = "terminado"
-version = "0.18.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ptyprocess", marker = "os_name != 'nt'" },
-    { name = "pywinpty", marker = "os_name == 'nt'" },
-    { name = "tornado" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8a/11/965c6fd8e5cc254f1fe142d547387da17a8ebfd75a3455f637c663fb38a0/terminado-0.18.1.tar.gz", hash = "sha256:de09f2c4b85de4765f7714688fff57d3e75bad1f909b589fde880460c753fd2e", size = 32701, upload-time = "2024-03-12T14:34:39.026Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/9e/2064975477fdc887e47ad42157e214526dcad8f317a948dee17e1659a62f/terminado-0.18.1-py3-none-any.whl", hash = "sha256:a4468e1b37bb318f8a86514f65814e1afc977cf29b3992a4500d9dd305dcceb0", size = 14154, upload-time = "2024-03-12T14:34:36.569Z" },
-]
-
-[[package]]
 name = "threadpoolctl"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3998,27 +2797,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b7/38/5e2ecef5af2f4fd4a89bb8d6240de9458bab4d51a4cbd97aeb3a0cd618e2/tifffile-2026.6.1.tar.gz", hash = "sha256:626c892c0e899d959b9438e7c0e1491dc154a7fead1f1f37a991724a50eceba9", size = 429694, upload-time = "2026-05-31T23:57:12.165Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/59/208f71d70ddc6184f79b8c6d87d46eb7d7b12c19186a817dec9c9c3f3693/tifffile-2026.6.1-py3-none-any.whl", hash = "sha256:0d7382d2769b855b81ce358528e2b40c16d48aa39031746efa81215205332a8d", size = 267108, upload-time = "2026-05-31T23:57:10.597Z" },
-]
-
-[[package]]
-name = "tinycss2"
-version = "1.5.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "webencodings" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/ae/2ca4913e5c0f09781d75482874c3a95db9105462a92ddd303c7d285d3df2/tinycss2-1.5.1.tar.gz", hash = "sha256:d339d2b616ba90ccce58da8495a78f46e55d4d25f9fd71dfd526f07e7d53f957", size = 88195, upload-time = "2025-11-23T10:29:10.082Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/45/c7b5c3168458db837e8ceab06dc77824e18202679d0463f0e8f002143a97/tinycss2-1.5.1-py3-none-any.whl", hash = "sha256:3415ba0f5839c062696996998176c4a3751d18b7edaaeeb658c9ce21ec150661", size = 28404, upload-time = "2025-11-23T10:29:08.676Z" },
-]
-
-[[package]]
-name = "tomli-w"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
 ]
 
 [[package]]
@@ -4127,39 +2905,12 @@ wheels = [
 ]
 
 [[package]]
-name = "typer"
-version = "0.26.7"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "annotated-doc" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "rich" },
-    { name = "shellingham" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/ed/ef06584ccdd5c410df0837951ecd7e15d9a6144ea1bd4c73cecab1a89891/typer-0.26.7.tar.gz", hash = "sha256:e314a34c617e419c091b2830dda3ea1f257134ff593061a8f5b9717ab8dddb3a", size = 201709, upload-time = "2026-06-03T07:18:06.843Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/25/2201973529af2c954de0bb725323c3aaed6d7f0ceee8f550dec9185df013/typer-0.26.7-py3-none-any.whl", hash = "sha256:5c87cfbc5d34491c5346ebf49c23e18d56ccb863268d3a8d592b26087c2f5e58", size = 122456, upload-time = "2026-06-03T07:18:05.732Z" },
-]
-
-[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
-]
-
-[[package]]
-name = "typing-inspection"
-version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]
@@ -4187,27 +2938,6 @@ wheels = [
 ]
 
 [[package]]
-name = "umf"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "tcmlib" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/72/2e0182f4e6a727a15d0a8a99a82182a4f5bdec1a4f5767acfd2abdc72070/umf-1.1.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:567152c5ee6b8e16cc56b29a8a9a6b918de1febf89877f71ea2e8247ef39fc32", size = 424455, upload-time = "2026-04-24T14:13:51.436Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/43/d89fee46bed22a461714a8786b833a89bff2f0a5e058b02eed3be842752e/umf-1.1.0-py2.py3-none-win_amd64.whl", hash = "sha256:a8c5ff84901fe6348715b6c1c85de4d195a6c69185d99ce4ebf7449b5d04011c", size = 289901, upload-time = "2026-04-24T14:08:31.647Z" },
-]
-
-[[package]]
-name = "uri-template"
-version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/31/c7/0336f2bd0bcbada6ccef7aaa25e443c118a704f828a0620c6fa0207c1b64/uri-template-1.3.0.tar.gz", hash = "sha256:0e00f8eb65e18c7de20d595a14336e9f337ead580c70934141624b6d1ffdacc7", size = 21678, upload-time = "2023-06-21T01:49:05.374Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl", hash = "sha256:a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363", size = 11140, upload-time = "2023-06-21T01:49:03.467Z" },
-]
-
-[[package]]
 name = "urllib3"
 version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4217,64 +2947,12 @@ wheels = [
 ]
 
 [[package]]
-name = "vispy"
-version = "0.15.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "freetype-py" },
-    { name = "hsluv" },
-    { name = "kiwisolver" },
-    { name = "numpy" },
-    { name = "packaging" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/2e/ef2697f963111cf1bc83568bbe55f262b7c7c8a72948a6e802a7c236f2c1/vispy-0.15.2.tar.gz", hash = "sha256:d52d10c0697f48990555cea2a2bad3f9f5a772391856fda364ea4bbc69fd075c", size = 2513383, upload-time = "2025-05-19T13:26:41.015Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/7e/31102425ea26bafab27bb5a675b499c57d29e72b1cc25fe3ae8facdd374e/vispy-0.15.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c8cbc22bc789f238423abadfcc3ba7589b85729be6b179b321720b511012fbee", size = 1478919, upload-time = "2025-05-19T13:26:16.962Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/63/a601b8f1e8e418d3821d7b4a465c2eb6695ab8eccadfce886b99ffdfe92a/vispy-0.15.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bf995b86dcc1eab265fa2bf9a8a5ca5a225b86c3ed4ac63900f0c5e90d5e8100", size = 1471915, upload-time = "2025-05-19T13:26:18.441Z" },
-    { url = "https://files.pythonhosted.org/packages/79/1f/ca0deb4a876148c0fa515bf03d03e1dfad4553be8e6f2ab51433c074310b/vispy-0.15.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0aa64fcab1cd1730a10a1c9188e9cef8aefe6d099a46f2f87e2458bcef719918", size = 1866848, upload-time = "2025-05-19T13:26:19.6Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/a4/dc6f335e54877f5d26ad4e4aac8f49b2d6e7719dee3e08f363d882c8aba4/vispy-0.15.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e9d38228cedd23876cb2359ff568d523a97284d225259d450d5e5e2129e98eb1", size = 1870433, upload-time = "2025-05-19T13:26:20.794Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/73/5ffa34d7300c35e8423d51789d594d35eaa7256d210f9909afa9fdd0aa37/vispy-0.15.2-cp312-cp312-win_amd64.whl", hash = "sha256:a84531c1a89f8b9d3992eb0d0ab74f84884f49d1f46a8be3755c809d7507cb01", size = 1468068, upload-time = "2025-05-19T13:26:22.073Z" },
-    { url = "https://files.pythonhosted.org/packages/85/9a/6664b7f0d28e0008a28111bae847a1fa3eedd409458bf01ca45a6e99da6f/vispy-0.15.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2ac46aab46e208b919dcf0bb26869bcd083a0a1a4927bcaf41631ba38c247639", size = 1477880, upload-time = "2025-05-19T13:26:23.321Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/6f/b9b36f841c5ff7320764f64822e79df3fea8a2c92270cda7f3a634d9a031/vispy-0.15.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7e197a012503850a77d47177964d572edab964b2a8ea0f9d998c35b81325256c", size = 1471035, upload-time = "2025-05-19T13:26:24.554Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/af/b892a3c9b4be29755ce4d1fc17ecb8249446bdd0e17bb5b2a9cb39bcf0f4/vispy-0.15.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6d9eff397ecdbaf0052baae0563caa9e276272d6dc78fbaab3f5e51dbf5f7f92", size = 1860412, upload-time = "2025-05-19T13:26:26.212Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/13/8997d96bdc0a81f331dfd41b368935d79e8ea2917840266567e6dc40d684/vispy-0.15.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f13ee0cb95bbff6d7b235e1a8f96e620eee15ccb6d5ad74902427ab7e56dc8ab", size = 1865860, upload-time = "2025-05-19T13:26:27.928Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/37/abb30db1853b69aed4c32813cf312f301ec3641b8846193be9a6d892d607/vispy-0.15.2-cp313-cp313-win_amd64.whl", hash = "sha256:f5955821e9b452980490706648a702da8cb2b82e762b6d6589e5872118301b84", size = 1467882, upload-time = "2025-05-19T13:26:29.608Z" },
-]
-
-[[package]]
 name = "wcwidth"
 version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/49/b4/51fe890511f0f242d07cb1ebe6a5b6db417262b9d2568b460347c57d95cc/wcwidth-0.8.1.tar.gz", hash = "sha256:faf5b4a5366a72dc49cad48cdf21f52bdf63bdda995178e483ba247ff79089b9", size = 1466072, upload-time = "2026-06-08T05:57:23.146Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl", hash = "sha256:f453740b1e4a4f3291faa37944c555d71056c4da08d59809b307ef4feba695c8", size = 323092, upload-time = "2026-06-08T05:57:21.413Z" },
-]
-
-[[package]]
-name = "webcolors"
-version = "25.10.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1d/7a/eb316761ec35664ea5174709a68bbd3389de60d4a1ebab8808bfc264ed67/webcolors-25.10.0.tar.gz", hash = "sha256:62abae86504f66d0f6364c2a8520de4a0c47b80c03fc3a5f1815fedbef7c19bf", size = 53491, upload-time = "2025-10-31T07:51:03.977Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl", hash = "sha256:032c727334856fc0b968f63daa252a1ac93d33db2f5267756623c210e57a4f1d", size = 14905, upload-time = "2025-10-31T07:51:01.778Z" },
-]
-
-[[package]]
-name = "webencodings"
-version = "0.5.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
-]
-
-[[package]]
-name = "websocket-client"
-version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
 ]
 
 [[package]]
@@ -4308,57 +2986,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/39/62/75f18a0f03b4219c456652c7780e4d749b929eb605c098ce3a5b6b6bc081/wheel-0.47.0.tar.gz", hash = "sha256:cc72bd1009ba0cf63922e28f94d9d83b920aa2bb28f798a31d0691b02fa3c9b3", size = 63854, upload-time = "2026-04-22T15:51:27.727Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/1b/9e33c09813d65e248f7f773119148a612516a4bea93e9c6f545f78455b7c/wheel-0.47.0-py3-none-any.whl", hash = "sha256:212281cab4dff978f6cedd499cd893e1f620791ca6ff7107cf270781e587eced", size = 32218, upload-time = "2026-04-22T15:51:26.296Z" },
-]
-
-[[package]]
-name = "widgetsnbextension"
-version = "4.0.15"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bd/f4/c67440c7fb409a71b7404b7aefcd7569a9c0d6bd071299bf4198ae7a5d95/widgetsnbextension-4.0.15.tar.gz", hash = "sha256:de8610639996f1567952d763a5a41af8af37f2575a41f9852a38f947eb82a3b9", size = 1097402, upload-time = "2025-11-01T21:15:55.178Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/0e/fa3b193432cfc60c93b42f3be03365f5f909d2b3ea410295cf36df739e31/widgetsnbextension-4.0.15-py3-none-any.whl", hash = "sha256:8156704e4346a571d9ce73b84bee86a29906c9abfd7223b7228a28899ccf3366", size = 2196503, upload-time = "2025-11-01T21:15:53.565Z" },
-]
-
-[[package]]
-name = "wrapt"
-version = "2.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/a4/282c8e64300a59fc834518a54bf0afabb4ff9218b5fa76958b450459a844/wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302", size = 129068, upload-time = "2026-06-20T23:49:44.49Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/85/180b40628b23772692a0c76e8030114e1c0ae068470ed531919f0a5f2a4a/wrapt-2.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8417fd3c674d3c8023d080292d29301531a12daf8bd938dd419710dd2f464f2b", size = 81484, upload-time = "2026-06-20T23:47:59.924Z" },
-    { url = "https://files.pythonhosted.org/packages/94/f2/21c90f2a16689702e2aaff45795b11018dff2c9b1242bac10d225483f676/wrapt-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e7070c7472582e31af3dfc2622b2381a0df7435110a9388ed8db5ffbce67efb", size = 82151, upload-time = "2026-06-20T23:48:01.303Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/b3/7e6e9fcf4fe7e1b69a49fe6cc5a44e8224bab6283c5233c97e132f14908e/wrapt-2.2.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2e096c9d39a59b35b63c9aacfbbbec2088ff51ff1fc31051acc60a07f42f273a", size = 169828, upload-time = "2026-06-20T23:48:02.719Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/43/894f132d857ed5a9904d937baf368badcbe5ea9e436e2f1930fe21c9f1f0/wrapt-2.2.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d1a6050405bf334be33bf66296f113563622972a34900ae6fa60fd283a1a900", size = 171544, upload-time = "2026-06-20T23:48:04.266Z" },
-    { url = "https://files.pythonhosted.org/packages/29/de/3c833e03725b477e9ea34028224dd21a48781830101e4e036f77e8b6b102/wrapt-2.2.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10adb01371408c6de504a6658b9886480f1a4919a83752748a387a504a21df79", size = 160663, upload-time = "2026-06-20T23:48:05.708Z" },
-    { url = "https://files.pythonhosted.org/packages/33/be/27edce350b24e3054d9d047f65f16d4c4d4c1f3f31c4278a1f8a95c723c8/wrapt-2.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3442eee2a5798f9b451f1b2cd7518ce8b7e28a2a364696c414460a0e295c012a", size = 169387, upload-time = "2026-06-20T23:48:07.243Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/c4/9fd9679af8bf38e146652c7f47b6b352c3e5795b4ad1c0b7f94e15ac2aa7/wrapt-2.2.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6c99012a22f735a85eed7c4b86a3e99c30fdd57d9e115b2b45f796264b58d0bf", size = 158849, upload-time = "2026-06-20T23:48:08.91Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/c2/aa6c0c2206803068c6859dabe01f8c84c43744da93d4c67b8946d21655ee/wrapt-2.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3b686cfc008776a3952d6213cb296ed7f45d782a8453936406faa89eac0835ab", size = 168147, upload-time = "2026-06-20T23:48:10.374Z" },
-    { url = "https://files.pythonhosted.org/packages/42/63/3eb25da41049d20ae18fcab2dd8b056e02387c4bfa626cbdfb7c3b872e4f/wrapt-2.2.2-cp312-cp312-win32.whl", hash = "sha256:ef2cce266b5b0b07e19fa82e59673b81142b7a3607c8ed1254113d048ed668da", size = 77734, upload-time = "2026-06-20T23:48:11.769Z" },
-    { url = "https://files.pythonhosted.org/packages/da/09/0390e008a305360948fa9ce69507d041ac12cb2ee5d28e34467e2ee79391/wrapt-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:abf8c20a2d72ee69e16328b3c91342c446e723bfe48bfcc4dded3b9722ac027f", size = 80585, upload-time = "2026-06-20T23:48:13.117Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/b3/84c445c66969f2d3457276b183a48c91097d59bbef9af6c075366b0f8c36/wrapt-2.2.2-cp312-cp312-win_arm64.whl", hash = "sha256:c6c64c5d02578bc4c4bca4f0aef1504de933c1d5b4ac2710b9131111459506c8", size = 79553, upload-time = "2026-06-20T23:48:14.5Z" },
-    { url = "https://files.pythonhosted.org/packages/43/fc/f32f4b22c6511173c11d9e541ab4e7d8467a0f1b3455acaf784115d31ff8/wrapt-2.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9e8b648270c613720a202d9a45ebabc33261b22c3a839b115ac5bce8c0bb0d69", size = 81296, upload-time = "2026-06-20T23:48:15.881Z" },
-    { url = "https://files.pythonhosted.org/packages/72/06/4d117d5d77a9344776c0248b24dae3d3dd2f58e5f765fa08cf887072e719/wrapt-2.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6fb7e94e8fe3e4c3067bb1653a91cce7c5e83acc119fdd41501b1bf74654617", size = 81841, upload-time = "2026-06-20T23:48:17.262Z" },
-    { url = "https://files.pythonhosted.org/packages/15/ff/63ad96f98eb58a742b1a20d80f21da88924405910149950b912368150468/wrapt-2.2.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb18fc51e813df0d9c98049e3bf2298a5495a648602040e21fa3c7329371159e", size = 167882, upload-time = "2026-06-20T23:48:18.764Z" },
-    { url = "https://files.pythonhosted.org/packages/20/1f/8bb62d8933df7acf3247194e6e9fc68edf9d2fa203252c89c94b319dd472/wrapt-2.2.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94b00b00f806eb3ef2abe9049ed45994a81ee9284884d96e6b8314927c6cea3d", size = 167411, upload-time = "2026-06-20T23:48:20.315Z" },
-    { url = "https://files.pythonhosted.org/packages/17/09/8789dcb09ee1de715727db7521aabbb68ffa68dfade3a49468440cfced49/wrapt-2.2.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:62415fd095bc590b842b6d092f2b5d9ccbaeb7e0b28535c03dcea2718b48636b", size = 158607, upload-time = "2026-06-20T23:48:21.728Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/20/66e02562d53ee67d841f175e38e3c993c2d78a3e104c576cad61c028b43c/wrapt-2.2.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a41e758d80dc0ab8c210f641ac892009d356cf1f955d97db544c8dd317b4d14c", size = 166367, upload-time = "2026-06-20T23:48:23.177Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/a3/832ac4e41222fb263b3042d42c2f08d305db7d0f0c9b1d3a271a9eede8f6/wrapt-2.2.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b84cd4058001c9727b0e9980b7a9e66325b5ca748b1b578e822cade1bc6b304f", size = 157176, upload-time = "2026-06-20T23:48:24.711Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/01/1bd5e4d2df9c0178989ac8da9186543465388588ee2ef153e2591accebef/wrapt-2.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:26fc73a1b15e0946d2942b9a4426d162b51676338327dc067ccd8d2d76385f94", size = 167025, upload-time = "2026-06-20T23:48:26.118Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/69/583ed25291ab53e1ec117135fb1c33425e2f46d2bc8f29c17f7a94cf4274/wrapt-2.2.2-cp313-cp313-win32.whl", hash = "sha256:3c4095803491f6ef72128914c28ec05bbad9758433bb35f6715a3e9c8e46fb2d", size = 77605, upload-time = "2026-06-20T23:48:27.643Z" },
-    { url = "https://files.pythonhosted.org/packages/29/68/e69fc6d06e1523c68e0d00f95c9aed1158ce9908ee41603f7f2eae3d5db6/wrapt-2.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:2cb07f414fab25dbe6b5c7398e1491423a5c81a6209533639969a6c928d474a4", size = 80508, upload-time = "2026-06-20T23:48:29.013Z" },
-    { url = "https://files.pythonhosted.org/packages/55/21/fe7a393d9e5dc0923bed8f5d857e9dcff210f1fa0888c02cc8f3ffaa55aa/wrapt-2.2.2-cp313-cp313-win_arm64.whl", hash = "sha256:1fc7691f070220215cccb2a20836b9adbaecb8ff22ad47abe63de5f110994fac", size = 79565, upload-time = "2026-06-20T23:48:30.429Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/e5/c120d13bf5091164f68c3c1657e84f16f57e71d978421b626393ac5bd7eb/wrapt-2.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ec8f83949028366531383603139403cac7a826e4011955813cdd640017845ce5", size = 83264, upload-time = "2026-06-20T23:48:31.807Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/b0/d4a1eb97e0e286625bdf21bc7f702637f9607787ffbbdb5ec14d50c79dbf/wrapt-2.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4b481fb0c40d9fd90a5809911208da700987d373a20a4709dc9e3944af7a6bec", size = 83791, upload-time = "2026-06-20T23:48:33.482Z" },
-    { url = "https://files.pythonhosted.org/packages/18/1e/f060df47755e87b57684cee7bfc1362b204df55fac96ffebc0631b697b79/wrapt-2.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0065a3b657cec06813b4241d2462ccec287f6863103d7445b725fb3a889736f9", size = 203399, upload-time = "2026-06-20T23:48:34.97Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/de/2316a757a1abb6453700b79d83e532146dcef2611348282d4d8889792161/wrapt-2.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30f7424af5c5c345b7f26490e097f74a2ef45b3d08b664dc33571aee3bd3b56c", size = 210461, upload-time = "2026-06-20T23:48:36.569Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/29/d1160785ae18ca2495a6d82a21154103d74f656c9fd457fb35f6b11b965a/wrapt-2.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07fdcb012821859168641acf68afad61ef9783cf37100af85f152550e9677194", size = 195313, upload-time = "2026-06-20T23:48:38.175Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/2d/7caa9598ae61a9cf0989cc501739cbeeb7d650ab3193cca1407b9af0c6ab/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f90038ab58fafb584801ca62d72384d7d5225d93c76f7b773c22fae545bd8066", size = 206116, upload-time = "2026-06-20T23:48:39.804Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/02/281ea1088b8650d865f311b35cf86fd21df89128e2909714f1161e01c9d0/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c5d7825491bfa2d08b97e9557768987952c7b9ae687d06c3320b40a37ccb7f20", size = 192668, upload-time = "2026-06-20T23:48:41.346Z" },
-    { url = "https://files.pythonhosted.org/packages/be/7d/976e2d5b4b5c5babda40974edd54d0a5585cb60132ed86b46f4b80239b16/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ad520e6daa9bbf136f14de735474dbec7dcc0891f718e1d274ce8dc92e645af", size = 198891, upload-time = "2026-06-20T23:48:43.056Z" },
-    { url = "https://files.pythonhosted.org/packages/59/b7/e47651797c097f75a37e2ce86dcf04048ff576f3a674f7c558df7b5e9622/wrapt-2.2.2-cp313-cp313t-win32.whl", hash = "sha256:25904acb9475f46c24fe0423dbc8fda8cc5fbc282ab3dc6e72e919748c53f4e9", size = 78537, upload-time = "2026-06-20T23:48:44.509Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/6f/9fa5d59fb06d890defb5a8f727ce6a14d2932c8760153f96956628559fee/wrapt-2.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:305d4c247d61c4115794a169141823c62f719525ddb90b23aa332741c77d2c28", size = 82005, upload-time = "2026-06-20T23:48:46.391Z" },
-    { url = "https://files.pythonhosted.org/packages/15/80/4c7bd9873d1f9f7d138d93556b500469dbe24f42710b877519c2b9eb380d/wrapt-2.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c20279cd1a29800815d7b2d6338b60a6c6e78263f9d6e62e0eda251ba9cae2d0", size = 80762, upload-time = "2026-06-20T23:48:47.964Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- streaming.py — StreamingBinaryFile, a duck-typed stand-in for suite2p's BinaryFile. As f_raw it slices int16 frames from the lazy array; as f_reg it discards writes and reconstitutes registered frames on read by replaying saved shifts (bidiphase + rigid roll + nonrigid transform_data). Output is byte-identical to data.bin.
- streaming_array.py — RegisteredStreamArray, registered via the mbo_utilities.lazy_arrays entry point. Lets mbo <plane_dir> / imread(<plane_dir>) open a binary-less plane dir (ops.npy + reg_outputs.npy) as a lazy registered array. Isolated from streaming.py so a load failure can't break mbo_utilities.
- run_lsp.py — run_plane_stream() path and dispatch (stream=True); auto-falls back to the binary path for chan2/structural or .bin inputs; disables two_step_registration.
- cli.py — --reader-kwargs / writer-kwargs forwarding to mbo_utilities.imread/imwrite.
- Tests: test_streaming.py, test_streaming_array.py (byte-identity vs data.bin, write-discard, plugin load).